### PR TITLE
remove __connection_header for indigo

### DIFF
--- a/theora_image_transport/src/theora_subscriber.cpp
+++ b/theora_image_transport/src/theora_subscriber.cpp
@@ -237,7 +237,6 @@ void TheoraSubscriber::internalCallback(const theora_image_transport::PacketCons
                             header_info_.pic_width, header_info_.pic_height));
 
   latest_image_ = cv_bridge::CvImage(message->header, sensor_msgs::image_encodings::BGR8, bgr).toImageMsg();
-  latest_image_->__connection_header = message->__connection_header;
   /// @todo Handle RGB8 or MONO8 efficiently
   callback(latest_image_);
 }


### PR DESCRIPTION
`__connection_header` has removed from gencpp, as described in 
http://github.com/ros-perception/image_transport_plugins.git 

I created PR against groovy-devel, and it should work. but may be better to create `indigo-devel` branch in `image_transport_plugins`
