### PR TITLE
Added mechanism for decompression mode selection

### DIFF
--- a/compressed_image_transport/cfg/CompressedSubscriber.cfg
+++ b/compressed_image_transport/cfg/CompressedSubscriber.cfg
@@ -1,0 +1,16 @@
+#! /usr/bin/env python
+
+PACKAGE='compressed_image_transport'
+import roslib; roslib.load_manifest(PACKAGE)
+
+from dynamic_reconfigure.parameter_generator import *
+
+gen = ParameterGenerator()
+
+mode_enum = gen.enum( [gen.const("unchanged", str_t, "unchanged", "keep image encoding"),
+                         gen.const("gray", str_t, "gray", "decode to gray"),
+                         gen.const("color", str_t, "color", "decode to color")],
+                        "Enum to set the decompression color mode" )
+gen.add("mode", str_t, 0, "Color Mode", "unchanged", edit_method = mode_enum)
+
+exit(gen.generate(PACKAGE, "CompressedSubscriber", "CompressedSubscriber"))

--- a/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
@@ -1,5 +1,7 @@
 #include "image_transport/simple_subscriber_plugin.h"
 #include <sensor_msgs/CompressedImage.h>
+#include <dynamic_reconfigure/server.h>
+#include <compressed_image_transport/CompressedSubscriberConfig.h>
 
 namespace compressed_image_transport {
 
@@ -14,8 +16,22 @@ public:
   }
 
 protected:
+  // Overridden to set up reconfigure server
+  virtual void subscribeImpl(ros::NodeHandle& nh, const std::string& base_topic, uint32_t queue_size,
+          const Callback& callback, const ros::VoidPtr& tracked_object,
+          const image_transport::TransportHints& transport_hints);
+
+
   virtual void internalCallback(const sensor_msgs::CompressedImageConstPtr& message,
                                 const Callback& user_cb);
+
+  typedef compressed_image_transport::CompressedSubscriberConfig Config;
+  typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
+  boost::shared_ptr<ReconfigureServer> reconfigure_server_;
+  Config config_;
+  int flags_;
+
+  void configCb(Config& config, uint32_t level);
 };
 
 } //namespace image_transport


### PR DESCRIPTION
This patch adds a parameter to the Jpeg subscriber to decide if I want to subscribe to the gray-level version of an image, independently of its original color. This would just require to expose the flag in cv::imdecode, to let the use specify something different than CV_LOAD_IMAGE_UNCHANGED.

The rationale for that: I have a webcam publishing jpegs, which I publish directly as a compressed topic. For data logging, they have to stay in color, however for any on-board processing, I need gray. Currently, the image are decompressed to BGR, which involves a conversion from YCbCr, and then a conversion from BGR to gray. Given that Y is the gray value, converting directly to gray from YCbCr would make more sense on my embedded system. 
