### PR TITLE
Added mechanism for decompression mode selection

### DIFF
--- a/compressed_image_transport/CMakeLists.txt
+++ b/compressed_image_transport/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(OpenCV REQUIRED)
 find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure image_transport tf)
 
 # generate the dynamic_reconfigure config file
-generate_dynamic_reconfigure_options(cfg/CompressedPublisher.cfg)
+generate_dynamic_reconfigure_options(cfg/CompressedPublisher.cfg cfg/CompressedSubscriber.cfg)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/compressed_image_transport/cfg/CompressedSubscriber.cfg
+++ b/compressed_image_transport/cfg/CompressedSubscriber.cfg
@@ -1,0 +1,15 @@
+#! /usr/bin/env python
+
+PACKAGE='compressed_image_transport'
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+mode_enum = gen.enum( [gen.const("unchanged", str_t, "unchanged", "keep image encoding"),
+                         gen.const("gray", str_t, "gray", "decode to gray"),
+                         gen.const("color", str_t, "color", "decode to color")],
+                        "Enum to set the decompression color mode" )
+gen.add("mode", str_t, 0, "Color Mode", "unchanged", edit_method = mode_enum)
+
+exit(gen.generate(PACKAGE, "CompressedSubscriber", "CompressedSubscriber"))

--- a/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
@@ -63,7 +63,7 @@ protected:
   typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
   boost::shared_ptr<ReconfigureServer> reconfigure_server_;
   Config config_;
-  int flags_;
+  int imdecode_flag_;
 
   void configCb(Config& config, uint32_t level);
 };

--- a/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
@@ -34,6 +34,8 @@
 
 #include "image_transport/simple_subscriber_plugin.h"
 #include <sensor_msgs/CompressedImage.h>
+#include <dynamic_reconfigure/server.h>
+#include <compressed_image_transport/CompressedSubscriberConfig.h>
 
 namespace compressed_image_transport {
 
@@ -48,8 +50,22 @@ public:
   }
 
 protected:
+  // Overridden to set up reconfigure server
+  virtual void subscribeImpl(ros::NodeHandle& nh, const std::string& base_topic, uint32_t queue_size,
+          const Callback& callback, const ros::VoidPtr& tracked_object,
+          const image_transport::TransportHints& transport_hints);
+
+
   virtual void internalCallback(const sensor_msgs::CompressedImageConstPtr& message,
                                 const Callback& user_cb);
+
+  typedef compressed_image_transport::CompressedSubscriberConfig Config;
+  typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
+  boost::shared_ptr<ReconfigureServer> reconfigure_server_;
+  Config config_;
+  int flags_;
+
+  void configCb(Config& config, uint32_t level);
 };
 
 } //namespace image_transport

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -83,9 +83,9 @@ void CompressedPublisher::publish(const sensor_msgs::Image& message, const Publi
 
   // Get codec configuration
   compressionFormat encodingFormat = UNDEFINED;
-  if (config_.format == "jpeg")
+  if (config_.format == compressed_image_transport::CompressedPublisher_jpeg)
     encodingFormat = JPEG;
-  if (config_.format == "png")
+  if (config_.format == compressed_image_transport::CompressedPublisher_png)
     encodingFormat = PNG;
 
   // Bit depth of image encoding

--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -67,11 +67,11 @@ void CompressedSubscriber::subscribeImpl(ros::NodeHandle& nh, const std::string&
 void CompressedSubscriber::configCb(Config& config, uint32_t level)
 {
   config_ = config;
-  if (config_.mode == "gray") {
+  if (config_.mode == compressed_image_transport::CompressedSubscriber_gray) {
       imdecode_flag_ = cv::IMREAD_GRAYSCALE;
-  } else if (config_.mode == "color") {
+  } else if (config_.mode == compressed_image_transport::CompressedSubscriber_color) {
       imdecode_flag_ = cv::IMREAD_COLOR;
-  } else /*if (config_.mode == "unchanged")*/ {
+  } else /*if (config_.mode == compressed_image_transport::CompressedSubscriber_unchanged)*/ {
       imdecode_flag_ = cv::IMREAD_UNCHANGED;
   } 
 }

--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -68,11 +68,11 @@ void CompressedSubscriber::configCb(Config& config, uint32_t level)
 {
   config_ = config;
   if (config_.mode == "gray") {
-      flags_ = CV_LOAD_IMAGE_GRAYSCALE;
+      flags_ = cv::IMREAD_GRAYSCALE;
   } else if (config_.mode == "gray") {
-      flags_ = CV_LOAD_IMAGE_COLOR;
+      flags_ = cv::IMREAD_COLOR;
   } else /*if (config_.mode == "unchanged")*/ {
-      flags_ = CV_LOAD_IMAGE_UNCHANGED;
+      flags_ = cv::IMREAD_UNCHANGED;
   } 
 }
 
@@ -90,7 +90,7 @@ void CompressedSubscriber::internalCallback(const sensor_msgs::CompressedImageCo
   // Decode color/mono image
   try
   {
-    cv_ptr->image = cv::imdecode(cv::Mat(message->data), CV_LOAD_IMAGE_UNCHANGED);
+    cv_ptr->image = cv::imdecode(cv::Mat(message->data), cv::IMREAD_UNCHANGED);
 
     // Assign image encoding string
     const size_t split_pos = message->format.find(';');

--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -68,11 +68,11 @@ void CompressedSubscriber::configCb(Config& config, uint32_t level)
 {
   config_ = config;
   if (config_.mode == "gray") {
-      flags_ = cv::IMREAD_GRAYSCALE;
-  } else if (config_.mode == "gray") {
-      flags_ = cv::IMREAD_COLOR;
+      imdecode_flag_ = cv::IMREAD_GRAYSCALE;
+  } else if (config_.mode == "color") {
+      imdecode_flag_ = cv::IMREAD_COLOR;
   } else /*if (config_.mode == "unchanged")*/ {
-      flags_ = cv::IMREAD_UNCHANGED;
+      imdecode_flag_ = cv::IMREAD_UNCHANGED;
   } 
 }
 
@@ -90,7 +90,7 @@ void CompressedSubscriber::internalCallback(const sensor_msgs::CompressedImageCo
   // Decode color/mono image
   try
   {
-    cv_ptr->image = cv::imdecode(cv::Mat(message->data), cv::IMREAD_UNCHANGED);
+    cv_ptr->image = cv::imdecode(cv::Mat(message->data), imdecode_flag_);
 
     // Assign image encoding string
     const size_t split_pos = message->format.find(';');

--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -50,6 +50,33 @@ namespace enc = sensor_msgs::image_encodings;
 namespace compressed_image_transport
 {
 
+void CompressedSubscriber::subscribeImpl(ros::NodeHandle& nh, const std::string& base_topic, uint32_t queue_size,
+                             const Callback& callback, const ros::VoidPtr& tracked_object,
+                             const image_transport::TransportHints& transport_hints)
+{
+    typedef image_transport::SimpleSubscriberPlugin<sensor_msgs::CompressedImage> Base;
+    Base::subscribeImpl(nh, base_topic, queue_size, callback, tracked_object, transport_hints);
+
+    // Set up reconfigure server for this topic
+    reconfigure_server_ = boost::make_shared<ReconfigureServer>(this->nh());
+    ReconfigureServer::CallbackType f = boost::bind(&CompressedSubscriber::configCb, this, _1, _2);
+    reconfigure_server_->setCallback(f);
+}
+
+
+void CompressedSubscriber::configCb(Config& config, uint32_t level)
+{
+  config_ = config;
+  if (config_.mode == "gray") {
+      flags_ = CV_LOAD_IMAGE_GRAYSCALE;
+  } else if (config_.mode == "gray") {
+      flags_ = CV_LOAD_IMAGE_COLOR;
+  } else /*if (config_.mode == "unchanged")*/ {
+      flags_ = CV_LOAD_IMAGE_UNCHANGED;
+  } 
+}
+
+
 void CompressedSubscriber::internalCallback(const sensor_msgs::CompressedImageConstPtr& message,
                                             const Callback& user_cb)
 


### PR DESCRIPTION
Trying again to make sure the pull request is against indigo. 

This patch adds a parameter to the Jpeg subscriber to decide if I want to subscribe to the gray-level version of an image, independently of its original color. This would just require to expose the flag in cv::imdecode, to let the use specify something different than CV_LOAD_IMAGE_UNCHANGED.

The rationale for that: I have a webcam publishing jpegs, which I publish directly as a compressed topic. For data logging, they have to stay in color, however for any on-board processing, I need gray. Currently, the image are decompressed to BGR, which involves a conversion from YCbCr, and then a conversion from BGR to gray. Given that Y is the gray value, converting directly to gray from YCbCr would make more sense on my embedded system.

https://github.com/ros-perception/image_transport_plugins/pull/16
