### PR TITLE
address gcc6 build error and tune

### DIFF
--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -18,8 +18,7 @@ catkin_package(
   DEPENDS OpenCV
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/compressed_depth_publisher.cpp src/compressed_depth_subscriber.cpp src/manifest.cpp src/codec.cpp)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)

--- a/compressed_image_transport/CMakeLists.txt
+++ b/compressed_image_transport/CMakeLists.txt
@@ -14,8 +14,7 @@ catkin_package(
   DEPENDS OpenCV
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/compressed_publisher.cpp src/compressed_subscriber.cpp src/manifest.cpp)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)

--- a/theora_image_transport/CMakeLists.txt
+++ b/theora_image_transport/CMakeLists.txt
@@ -24,8 +24,9 @@ catkin_package(
   CATKIN_DEPENDS message_runtime std_msgs
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
-include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS}
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
   ${PC_OGG_INCLUDE_DIRS}
   ${PC_THEORA_INCLUDE_DIRS}
   ${PC_THEORAENC_INCLUDE_DIRS}


### PR DESCRIPTION
With gcc6, compiling fails with `stdlib.h: No such file or directory`, as including '-isystem /usr/include' breaks with gcc6, cf., https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.

This commit addresses this issue for this package in the same way it was addressed in various other ROS packages. A list of related commits and pull requests is at https://github.com/ros/rosdistro/issues/12783.
