### PR TITLE
Update compress_depth_image_transport to ROS2

### DIFF
--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -1,40 +1,53 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
+
 project(compressed_depth_image_transport)
 
-if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-#  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
-
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+find_package(ament_cmake REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(OpenCV REQUIRED)
-find_package(catkin REQUIRED cv_bridge dynamic_reconfigure image_transport)
 
-# generate the dynamic_reconfigure config file
-generate_dynamic_reconfigure_options(cfg/CompressedDepthPublisher.cfg)
+include_directories(include ${OpenCV_INCLUDE_DIRS})
 
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS cv_bridge dynamic_reconfigure image_transport
-  DEPENDS OpenCV
+add_library(
+    ${PROJECT_NAME}
+    SHARED
+    src/compressed_depth_publisher.cpp
+    src/compressed_depth_subscriber.cpp
+    src/manifest.cpp src/codec.cpp
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})
 
-add_library(${PROJECT_NAME} src/compressed_depth_publisher.cpp src/compressed_depth_subscriber.cpp src/manifest.cpp src/codec.cpp)
-add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
-
-class_loader_hide_library_symbols(${PROJECT_NAME})
+ament_target_dependencies(${PROJECT_NAME}
+  "image_transport"
+  "cv_bridge"
+  "rclcpp"
+  "pluginlib"
+  "sensor_msgs"
+)
 
 install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-)
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
-# add xml file
-install(FILES compressed_depth_plugins.xml
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+install(
+  DIRECTORY "include/"
+  DESTINATION include
 )
+pluginlib_export_plugin_description_file(image_transport
+    compressed_depth_plugins.xml)
+
+ament_package()

--- a/compressed_depth_image_transport/compressed_depth_plugins.xml
+++ b/compressed_depth_image_transport/compressed_depth_plugins.xml
@@ -1,11 +1,17 @@
-<library path="lib/libcompressed_depth_image_transport">
-  <class name="image_transport/compressedDepth_pub" type="compressed_depth_image_transport::CompressedDepthPublisher" base_class_type="image_transport::PublisherPlugin">
+<library path="libcompressed_depth_image_transport">
+  <class
+    name="image_transport/compressedDepth_pub"
+    type="compressed_depth_image_transport::CompressedDepthPublisher"
+    base_class_type="image_transport::PublisherPlugin">
     <description>
       This plugin publishes a compressed depth images using PNG compression.
     </description>
   </class>
 
-  <class name="image_transport/compressedDepth_sub" type="compressed_depth_image_transport::CompressedDepthSubscriber" base_class_type="image_transport::SubscriberPlugin">
+  <class
+    name="image_transport/compressedDepth_sub"
+    type="compressed_depth_image_transport::CompressedDepthSubscriber"
+    base_class_type="image_transport::SubscriberPlugin">
     <description>
       This plugin decodes a compressed depth images.
     </description>

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
@@ -35,23 +35,21 @@
 
 #include <opencv2/core/core.hpp>
 
-#include "sensor_msgs/CompressedImage.h"
-#include "sensor_msgs/Image.h"
-#include "sensor_msgs/image_encodings.h"
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/image_encodings.hpp>
 
 // Encoding and decoding of compressed depth images.
 namespace compressed_depth_image_transport
 {
 
 // Returns a null pointer on bad input.
-sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::CompressedImage& compressed_image);
+sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
+  const sensor_msgs::msg::CompressedImage& compressed_image);
 
 // Compress a depth image. The png_compression parameter is passed straight through to
 // OpenCV as IMWRITE_PNG_COMPRESSION. Returns a null pointer on bad input.
-sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
-    const sensor_msgs::Image& message,
-    double depth_max,
-    double depth_quantization,
-    int png_level);
+sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
+  const sensor_msgs::msg::Image& message);
 
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
@@ -50,6 +50,8 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
 // Compress a depth image. The png_compression parameter is passed straight through to
 // OpenCV as IMWRITE_PNG_COMPRESSION. Returns a null pointer on bad input.
 sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
-  const sensor_msgs::msg::Image& message);
-
+  const sensor_msgs::msg::Image& message,
+  double depth_max = 10.0,
+  double depth_quantization = 100.0,
+  int png_level = 9);
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.h
@@ -53,10 +53,10 @@ protected:
   virtual void advertiseImpl(
           rclcpp::Node::SharedPtr node,
           const std::string &base_topic,
-          rmw_qos_profile_t custom_qos);
+          rmw_qos_profile_t custom_qos) override final;
 
   virtual void publish(const sensor_msgs::msg::Image& message,
-                       const PublishFn& publish_fn) const;
+                       const PublishFn& publish_fn) const override final;
 };
 
 } //namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.h
@@ -32,14 +32,13 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
 #include "image_transport/simple_publisher_plugin.h"
-#include <sensor_msgs/CompressedImage.h>
-#include <dynamic_reconfigure/server.h>
-#include <compressed_depth_image_transport/CompressedDepthPublisherConfig.h>
 
 namespace compressed_depth_image_transport {
 
-class CompressedDepthPublisher : public image_transport::SimplePublisherPlugin<sensor_msgs::CompressedImage>
+class CompressedDepthPublisher : public image_transport::SimplePublisherPlugin<sensor_msgs::msg::CompressedImage>
 {
 public:
   virtual ~CompressedDepthPublisher() {}
@@ -51,20 +50,13 @@ public:
 
 protected:
   // Overridden to set up reconfigure server
-  virtual void advertiseImpl(ros::NodeHandle &nh, const std::string &base_topic, uint32_t queue_size,
-                             const image_transport::SubscriberStatusCallback  &user_connect_cb,
-                             const image_transport::SubscriberStatusCallback  &user_disconnect_cb,
-                             const ros::VoidPtr &tracked_object, bool latch);
-  
-  virtual void publish(const sensor_msgs::Image& message,
+  virtual void advertiseImpl(
+          rclcpp::Node::SharedPtr node,
+          const std::string &base_topic,
+          rmw_qos_profile_t custom_qos);
+
+  virtual void publish(const sensor_msgs::msg::Image& message,
                        const PublishFn& publish_fn) const;
-
-  typedef compressed_depth_image_transport::CompressedDepthPublisherConfig Config;
-  typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
-  boost::shared_ptr<ReconfigureServer> reconfigure_server_;
-  Config config_;
-
-  void configCb(Config& config, uint32_t level);
 };
 
 } //namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.h
@@ -57,6 +57,14 @@ protected:
 
   virtual void publish(const sensor_msgs::msg::Image& message,
                        const PublishFn& publish_fn) const override final;
+
+  struct Config {
+    int png_level;
+    double depth_max;
+    double depth_quantization;
+  };
+
+  Config config_;
 };
 
 } //namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_subscriber.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_subscriber.h
@@ -32,12 +32,15 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <string>
+#include <rclcpp/node.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
 #include "image_transport/simple_subscriber_plugin.h"
-#include <sensor_msgs/CompressedImage.h>
 
 namespace compressed_depth_image_transport {
 
-class CompressedDepthSubscriber : public image_transport::SimpleSubscriberPlugin<sensor_msgs::CompressedImage>
+class CompressedDepthSubscriber : public image_transport::SimpleSubscriberPlugin<sensor_msgs::msg::CompressedImage>
 {
 public:
   virtual ~CompressedDepthSubscriber() {}
@@ -48,7 +51,7 @@ public:
   }
 
 protected:
-  virtual void internalCallback(const sensor_msgs::CompressedImageConstPtr& message,
+  virtual void internalCallback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr& message,
                                 const Callback& user_cb);
 };
 

--- a/compressed_depth_image_transport/package.xml
+++ b/compressed_depth_image_transport/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>compressed_depth_image_transport</name>
   <version>1.9.5</version>
   <description>
@@ -11,18 +11,13 @@
   <url type="website">http://www.ros.org/wiki/image_transport_plugins</url>
   <author>Julius Kammerl</author>
 
-  <buildtool_depend>catkin</buildtool_depend>  
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>dynamic_reconfigure</build_depend>
-  <build_depend>image_transport</build_depend>
-
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>image_transport</run_depend>
+  <depend>cv_bridge</depend>
+  <depend>image_transport</depend>
 
   <export>
-    <rviz plugin="${prefix}/plugin_description.xml"/>
+    <build_type>ament_cmake</build_type>
     <image_transport plugin="${prefix}/compressed_depth_plugins.xml" />
   </export>
 </package>

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -39,7 +39,7 @@
 
 #include "cv_bridge/cv_bridge.h"
 #include <opencv2/highgui/highgui.hpp>
-#include <rcutils/logging_macros.h>
+#include <rclcpp/logging.hpp>
 
 #include "compressed_depth_image_transport/codec.h"
 #include "compressed_depth_image_transport/compression_common.h"
@@ -61,6 +61,8 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
 {
 
   cv_bridge::CvImagePtr cv_ptr(new cv_bridge::CvImage);
+
+  auto logger = rclcpp::get_logger("compressed_depth_image_transport");
 
   // Copy message header
   cv_ptr->header = message.header;
@@ -97,7 +99,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
       }
       catch (cv::Exception& e)
       {
-        RCUTILS_LOG_ERROR(e.what());
+        RCLCPP_ERROR(logger, e.what());
         return sensor_msgs::msg::Image::SharedPtr();
       }
 
@@ -140,7 +142,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
       }
       catch (cv::Exception& e)
       {
-        RCUTILS_LOG_ERROR(e.what());
+        RCLCPP_ERROR(logger, e.what());
         return sensor_msgs::msg::Image::SharedPtr();
       }
 
@@ -167,6 +169,8 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
   sensor_msgs::msg::CompressedImage::SharedPtr compressed(new sensor_msgs::msg::CompressedImage());
   compressed->header = message.header;
   compressed->format = message.encoding;
+
+  auto logger = rclcpp::get_logger("compressed_depth_image_transport");
 
   // Compression settings
   std::vector<int> params;
@@ -203,7 +207,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
     }
     catch (cv_bridge::Exception& e)
     {
-      RCUTILS_LOG_ERROR(e.what());
+      RCLCPP_ERROR(logger, e.what());
       return sensor_msgs::msg::CompressedImage::SharedPtr();
     }
 
@@ -251,17 +255,18 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
         {
           float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
               / (float)compressedImage.size();
-          RCUTILS_LOG_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
+          RCLCPP_DEBUG(logger,
+                       "Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
         }
         else
         {
-          RCUTILS_LOG_ERROR("cv::imencode (png) failed on input image");
+          RCLCPP_ERROR(logger, "cv::imencode (png) failed on input image");
           return sensor_msgs::msg::CompressedImage::SharedPtr();
         }
       }
       catch (cv::Exception& e)
       {
-        RCUTILS_LOG_ERROR(e.msg.c_str());
+        RCLCPP_ERROR(logger, e.msg.c_str());
         return sensor_msgs::msg::CompressedImage::SharedPtr();
       }
     }
@@ -277,7 +282,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
     }
     catch (Exception& e)
     {
-      RCUTILS_LOG_ERROR(e.msg.c_str());
+      RCLCPP_ERROR(logger, e.msg.c_str());
       return sensor_msgs::msg::CompressedImage::SharedPtr();
     }
 
@@ -305,19 +310,20 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
       {
         float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
             / (float)compressedImage.size();
-        RCUTILS_LOG_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)",
-                          cRatio, compressedImage.size());
+        RCLCPP_DEBUG(logger,
+          "Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
       }
       else
       {
-        RCUTILS_LOG_ERROR("cv::imencode (png) failed on input image");
+        RCLCPP_ERROR(logger, "cv::imencode (png) failed on input image");
         return sensor_msgs::msg::CompressedImage::SharedPtr();
       }
     }
   }
   else
   {
-    RCUTILS_LOG_ERROR("Compressed Depth Image Transport - Compression requires single-channel 32bit-floating point or 16bit raw depth images (input format is: %s).", message.encoding.c_str());
+    RCLCPP_ERROR(logger,
+      "Compressed Depth Image Transport - Compression requires single-channel 32bit-floating point or 16bit raw depth images (input format is: %s).", message.encoding.c_str());
     return sensor_msgs::msg::CompressedImage::SharedPtr();
   }
 

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -37,9 +37,10 @@
 #include <string>
 #include <vector>
 
-#include <opencv2/highgui/highgui.hpp>
-
 #include "cv_bridge/cv_bridge.h"
+#include <opencv2/highgui/highgui.hpp>
+#include <rcutils/logging_macros.h>
+
 #include "compressed_depth_image_transport/codec.h"
 #include "compressed_depth_image_transport/compression_common.h"
 
@@ -96,7 +97,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
       }
       catch (cv::Exception& e)
       {
-        //ROS_ERROR("%s", e.what());
+        RCUTILS_LOG_ERROR(e.what());
         return sensor_msgs::msg::Image::SharedPtr();
       }
 
@@ -139,7 +140,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
       }
       catch (cv::Exception& e)
       {
-        //ROS_ERROR("%s", e.what());
+        RCUTILS_LOG_ERROR(%s);
         return sensor_msgs::msg::Image::SharedPtr();
       }
 
@@ -205,7 +206,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
     }
     catch (cv_bridge::Exception& e)
     {
-      //ROS_ERROR("%s", e.what());
+      RCUTILS_LOG_ERROR(%s);
       return sensor_msgs::msg::CompressedImage::SharedPtr();
     }
 
@@ -253,17 +254,17 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
         {
           float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
               / (float)compressedImage.size();
-          //ROS_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
+          RCUTILS_LOG_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
         }
         else
         {
-          //ROS_ERROR("cv::imencode (png) failed on input image");
+          RCUTILS_LOG_ERROR("cv::imencode (png) failed on input image");
           return sensor_msgs::msg::CompressedImage::SharedPtr();
         }
       }
       catch (cv::Exception& e)
       {
-        //ROS_ERROR("%s", e.msg.c_str());
+        RCUTILS_LOG_ERROR(e.msg.c_str());
         return sensor_msgs::msg::CompressedImage::SharedPtr();
       }
     }
@@ -279,7 +280,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
     }
     catch (Exception& e)
     {
-      //ROS_ERROR("%s", e.msg.c_str());
+      RCUTILS_LOG_ERROR(e.msg.c_str());
       return sensor_msgs::msg::CompressedImage::SharedPtr();
     }
 
@@ -311,14 +312,14 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
       }
       else
       {
-        //ROS_ERROR("cv::imencode (png) failed on input image");
+        RCUTILS_LOG_ERROR("cv::imencode (png) failed on input image");
         return sensor_msgs::msg::CompressedImage::SharedPtr();
       }
     }
   }
   else
   {
-    //ROS_ERROR("Compressed Depth Image Transport - Compression requires single-channel 32bit-floating point or 16bit raw depth images (input format is: %s).", message.encoding.c_str());
+    RCUTILS_LOG_ERROR("Compressed Depth Image Transport - Compression requires single-channel 32bit-floating point or 16bit raw depth images (input format is: %s).", message.encoding.c_str());
     return sensor_msgs::msg::CompressedImage::SharedPtr();
   }
 

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -42,7 +42,6 @@
 #include "cv_bridge/cv_bridge.h"
 #include "compressed_depth_image_transport/codec.h"
 #include "compressed_depth_image_transport/compression_common.h"
-#include "ros/ros.h"
 
 // If OpenCV3
 #ifndef CV_VERSION_EPOCH
@@ -56,7 +55,8 @@ using namespace cv;
 namespace compressed_depth_image_transport
 {
 
-sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::CompressedImage& message)
+sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
+  const sensor_msgs::msg::CompressedImage& message)
 {
 
   cv_bridge::CvImagePtr cv_ptr(new cv_bridge::CvImage);
@@ -96,8 +96,8 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
       }
       catch (cv::Exception& e)
       {
-        ROS_ERROR("%s", e.what());
-        return sensor_msgs::Image::Ptr();
+        //ROS_ERROR("%s", e.what());
+        return sensor_msgs::msg::Image::SharedPtr();
       }
 
       size_t rows = decompressed.rows;
@@ -139,8 +139,8 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
       }
       catch (cv::Exception& e)
       {
-        ROS_ERROR("%s", e.what());
-        return sensor_msgs::Image::Ptr();
+        //ROS_ERROR("%s", e.what());
+        return sensor_msgs::msg::Image::SharedPtr();
       }
 
       size_t rows = cv_ptr->image.rows;
@@ -153,16 +153,20 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
       }
     }
   }
-  return sensor_msgs::Image::Ptr();
+  return sensor_msgs::msg::Image::SharedPtr();
 }
 
-sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
-    const sensor_msgs::Image& message,
-    double depth_max, double depth_quantization, int png_level)
+sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
+    const sensor_msgs::msg::Image& message)
 {
+  // TODO: let the user change this hardcoded values using events or dynamic
+  // reconfigure
+  double depth_max = 10.0;
+  double depth_quantization = 100.0;
+  double png_level = 9;
 
   // Compressed image message
-  sensor_msgs::CompressedImage::Ptr compressed(new sensor_msgs::CompressedImage());
+  sensor_msgs::msg::CompressedImage::SharedPtr compressed(new sensor_msgs::msg::CompressedImage());
   compressed->header = message.header;
   compressed->format = message.encoding;
 
@@ -201,8 +205,8 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
     }
     catch (cv_bridge::Exception& e)
     {
-      ROS_ERROR("%s", e.what());
-      return sensor_msgs::CompressedImage::Ptr();
+      //ROS_ERROR("%s", e.what());
+      return sensor_msgs::msg::CompressedImage::SharedPtr();
     }
 
     const Mat& depthImg = cv_ptr->image;
@@ -249,18 +253,18 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
         {
           float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
               / (float)compressedImage.size();
-          ROS_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
+          //ROS_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
         }
         else
         {
-          ROS_ERROR("cv::imencode (png) failed on input image");
-          return sensor_msgs::CompressedImage::Ptr();
+          //ROS_ERROR("cv::imencode (png) failed on input image");
+          return sensor_msgs::msg::CompressedImage::SharedPtr();
         }
       }
       catch (cv::Exception& e)
       {
-        ROS_ERROR("%s", e.msg.c_str());
-        return sensor_msgs::CompressedImage::Ptr();
+        //ROS_ERROR("%s", e.msg.c_str());
+        return sensor_msgs::msg::CompressedImage::SharedPtr();
       }
     }
   }
@@ -275,8 +279,8 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
     }
     catch (Exception& e)
     {
-      ROS_ERROR("%s", e.msg.c_str());
-      return sensor_msgs::CompressedImage::Ptr();
+      //ROS_ERROR("%s", e.msg.c_str());
+      return sensor_msgs::msg::CompressedImage::SharedPtr();
     }
 
     const Mat& depthImg = cv_ptr->image;
@@ -303,19 +307,19 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
       {
         float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
             / (float)compressedImage.size();
-        ROS_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
+        //ROS_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
       }
       else
       {
-        ROS_ERROR("cv::imencode (png) failed on input image");
-        return sensor_msgs::CompressedImage::Ptr();
+        //ROS_ERROR("cv::imencode (png) failed on input image");
+        return sensor_msgs::msg::CompressedImage::SharedPtr();
       }
     }
   }
   else
   {
-    ROS_ERROR("Compressed Depth Image Transport - Compression requires single-channel 32bit-floating point or 16bit raw depth images (input format is: %s).", message.encoding.c_str());
-    return sensor_msgs::CompressedImage::Ptr();
+    //ROS_ERROR("Compressed Depth Image Transport - Compression requires single-channel 32bit-floating point or 16bit raw depth images (input format is: %s).", message.encoding.c_str());
+    return sensor_msgs::msg::CompressedImage::SharedPtr();
   }
 
   if (compressedImage.size() > 0)
@@ -330,7 +334,7 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
     return compressed;
   }
 
-  return sensor_msgs::CompressedImage::Ptr();
+  return sensor_msgs::msg::CompressedImage::SharedPtr();
 }
 
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -140,7 +140,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
       }
       catch (cv::Exception& e)
       {
-        RCUTILS_LOG_ERROR(%s);
+        RCUTILS_LOG_ERROR(e.what());
         return sensor_msgs::msg::Image::SharedPtr();
       }
 
@@ -158,14 +158,11 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
 }
 
 sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
-    const sensor_msgs::msg::Image& message)
+  const sensor_msgs::msg::Image& message,
+  double depth_max,
+  double depth_quantization,
+  int png_level)
 {
-  // TODO: let the user change this hardcoded values using events or dynamic
-  // reconfigure
-  double depth_max = 10.0;
-  double depth_quantization = 100.0;
-  double png_level = 9;
-
   // Compressed image message
   sensor_msgs::msg::CompressedImage::SharedPtr compressed(new sensor_msgs::msg::CompressedImage());
   compressed->header = message.header;
@@ -206,7 +203,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
     }
     catch (cv_bridge::Exception& e)
     {
-      RCUTILS_LOG_ERROR(%s);
+      RCUTILS_LOG_ERROR(e.what());
       return sensor_msgs::msg::CompressedImage::SharedPtr();
     }
 
@@ -308,7 +305,8 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
       {
         float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
             / (float)compressedImage.size();
-        //ROS_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
+        RCUTILS_LOG_DEBUG("Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)",
+                          cRatio, compressedImage.size());
       }
       else
       {

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -34,12 +34,13 @@
 
 #include "compressed_depth_image_transport/compressed_depth_publisher.h"
 #include <cv_bridge/cv_bridge.h>
-#include <sensor_msgs/image_encodings.h>
+#include <sensor_msgs/image_encodings.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#include <boost/make_shared.hpp>
 
 #include "compressed_depth_image_transport/codec.h"
 #include "compressed_depth_image_transport/compression_common.h"
+
+#include <rclcpp/parameter_client.hpp>
 
 #include <vector>
 #include <sstream>
@@ -52,29 +53,37 @@ namespace enc = sensor_msgs::image_encodings;
 namespace compressed_depth_image_transport
 {
 
-void CompressedDepthPublisher::advertiseImpl(ros::NodeHandle &nh, const std::string &base_topic, uint32_t queue_size,
-                                        const image_transport::SubscriberStatusCallback &user_connect_cb,
-                                        const image_transport::SubscriberStatusCallback &user_disconnect_cb,
-                                        const ros::VoidPtr &tracked_object, bool latch)
+void CompressedDepthPublisher::advertiseImpl(
+  rclcpp::Node::SharedPtr node,
+  const std::string& base_topic,
+  rmw_qos_profile_t custom_qos)
 {
-  typedef image_transport::SimplePublisherPlugin<sensor_msgs::CompressedImage> Base;
-  Base::advertiseImpl(nh, base_topic, queue_size, user_connect_cb, user_disconnect_cb, tracked_object, latch);
+  typedef image_transport::SimplePublisherPlugin<sensor_msgs::msg::CompressedImage> Base;
+  Base::advertiseImpl(node, base_topic, custom_qos);
 
-  // Set up reconfigure server for this topic
-  reconfigure_server_ = boost::make_shared<ReconfigureServer>(this->nh());
-  ReconfigureServer::CallbackType f = boost::bind(&CompressedDepthPublisher::configCb, this, _1, _2);
-  reconfigure_server_->setCallback(f);
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
+  while (!parameters_client->wait_for_service(1s)) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.")
+    }
+    RCLCPP_INFO(node->get_logger(), "service not available, waiting again...")
+  }
+
+  std::stringstream ss;
+  // Get a few of the parameters just set.
+  for (auto & parameter : parameters_client->get_parameters({"format"})) {
+    ss << "\nParameter name: " << parameter.get_name();
+    ss << "\nParameter value (" << parameter.get_type_name() << "): " <<
+      parameter.value_to_string();
+  }
 }
 
-void CompressedDepthPublisher::configCb(Config& config, uint32_t level)
+void CompressedDepthPublisher::publish(
+  const sensor_msgs::msg::Image& message,
+  const PublishFn& publish_fn) const
 {
-  config_ = config;
-}
-
-void CompressedDepthPublisher::publish(const sensor_msgs::Image& message, const PublishFn& publish_fn) const
-{
-  sensor_msgs::CompressedImage::Ptr compressed_image =
-      encodeCompressedDepthImage(message, config_.depth_max, config_.depth_quantization, config_.png_level);
+  sensor_msgs::msg::CompressedImage::SharedPtr compressed_image =
+    encodeCompressedDepthImage(message);
 
   if (compressed_image)
   {

--- a/compressed_depth_image_transport/src/compressed_depth_subscriber.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_subscriber.cpp
@@ -40,10 +40,11 @@
 namespace compressed_depth_image_transport
 {
 
-void CompressedDepthSubscriber::internalCallback(const sensor_msgs::CompressedImageConstPtr& message,
-                                            const Callback& user_cb)
+void CompressedDepthSubscriber::internalCallback(
+  const sensor_msgs::msg::CompressedImage::ConstSharedPtr& message,
+  const Callback& user_cb)
 {
-  sensor_msgs::Image::Ptr image = decodeCompressedDepthImage(*message);
+  sensor_msgs::msg::Image::Ptr image = decodeCompressedDepthImage(*message);
   if (image)
   {
     user_cb(image);

--- a/compressed_depth_image_transport/src/manifest.cpp
+++ b/compressed_depth_image_transport/src/manifest.cpp
@@ -1,13 +1,13 @@
 /*********************************************************************
 * Software License Agreement (BSD License)
-* 
+*
 *  Copyright (c) 20012, Willow Garage, Inc.
 *  All rights reserved.
-* 
+*
 *  Redistribution and use in source and binary forms, with or without
 *  modification, are permitted provided that the following conditions
 *  are met:
-* 
+*
 *   * Redistributions of source code must retain the above copyright
 *     notice, this list of conditions and the following disclaimer.
 *   * Redistributions in binary form must reproduce the above
@@ -17,7 +17,7 @@
 *   * Neither the name of the Willow Garage nor the names of its
 *     contributors may be used to endorse or promote products derived
 *     from this software without specific prior written permission.
-* 
+*
 *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -32,7 +32,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "compressed_depth_image_transport/compressed_depth_publisher.h"
 #include "compressed_depth_image_transport/compressed_depth_subscriber.h"
 


### PR DESCRIPTION
Mostly a clone of https://github.com/ros-perception/image_transport_plugins/pull/26. I think that the TODO applies here too:

 - [x] Use ros2 parameters to set encoding
 - [ ] Use parameter events to replace dynamic reconfigure.
