### PR TITLE
Add legacy constants when using opencv4.

### DIFF
--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -47,6 +47,11 @@
 // If OpenCV3
 #ifndef CV_VERSION_EPOCH
 #include <opencv2/imgcodecs.hpp>
+
+// If OpenCV4
+#if CV_VERSION_MAJOR > 3
+#include <opencv2/imgcodecs/legacy/constants_c.h>
+#endif
 #endif
 
 namespace enc = sensor_msgs::image_encodings;

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -43,6 +43,11 @@
 #include <vector>
 #include <sstream>
 
+// If OpenCV4
+#if CV_VERSION_MAJOR > 3
+#include <opencv2/imgcodecs/legacy/constants_c.h>
+#endif
+
 using namespace cv;
 using namespace std;
 


### PR DESCRIPTION
This PR adds compatibility for OpenCV4 (by including a legacy header if necessary).