### PR TITLE
[ROS2] Fixed portability warning for compressed depth plugin.

### DIFF
--- a/compressed_depth_image_transport/compressed_depth_plugins.xml
+++ b/compressed_depth_image_transport/compressed_depth_plugins.xml
@@ -1,4 +1,4 @@
-<library path="libcompressed_depth_image_transport">
+<library path="compressed_depth_image_transport">
   <class
     name="image_transport/compressedDepth_pub"
     type="compressed_depth_image_transport::CompressedDepthPublisher"


### PR DESCRIPTION
Not sure what this affects, but the old name gives a portability warning. Would love some feedback if it affects other stuff etc.