### PR TITLE
Update travis to test kinetic/melodic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,64 +1,11 @@
-sudo: required
-dist: trusty
 language: generic
+services:
+  - docker
 env:
-  - OPENCV_VERSION=2 ROS_DISTRO=indigo
-  - OPENCV_VERSION=3 ROS_DISTRO=indigo
-  - OPENCV_VERSION=2 ROS_DISTRO=jade
-  - OPENCV_VERSION=3 ROS_DISTRO=jade
-# Install system dependencies, namely ROS.
-before_install:
-  # Define some config vars.
-  - export ROS_CI_DESKTOP=`lsb_release -cs`  # e.g. [precise|trusty]
-  - export CI_SOURCE_PATH=$(pwd)
-  - export REPOSITORY_NAME=${PWD##*/}
-  - export ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
-  - export CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
-  - export ROS_PARALLEL_JOBS='-j8 -l6'
-  # Install ROS
-  - sudo sh -c "echo \"deb http://packages.ros.org/ros-shadow-fixed/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-  - sudo apt-get update -qq
-  # Install ROS
-  - sudo apt-get install -y python-catkin-pkg python-catkin-tools python-rosdep python-wstool ros-$ROS_DISTRO-catkin
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-  # Setup for rosdep
-  - sudo rosdep init
-  - rosdep update
-
-# Create a catkin workspace with the package under test.
+  matrix:
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="melodic"
 install:
-  - mkdir -p ~/catkin_ws/src
-
-  # Add the package under test to the workspace.
-  - cd ~/catkin_ws/src
-  - ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
-
-  - if [ $OPENCV_VERSION == 3 ]; then  sed -i 's@libopencv-dev@opencv3@' $REPOSITORY_NAME/*/package.xml ; fi
-
-# Install all dependencies, using wstool and rosdep.
-# wstool looks for a ROSINSTALL_FILE defined in before_install.
-before_script:
-  # source dependencies: install using wstool.
-  - cd ~/catkin_ws/src
-  - wstool init
-  - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
-  - wstool up
-
-  # package depdencies: install using rosdep.
-  - cd ~/catkin_ws
-  - rosdep install -q -y -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO
-
-# Compile and test.
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
 script:
-  - source /opt/ros/$ROS_DISTRO/setup.bash
-  - cd ~/catkin_ws
-  - catkin build -p1 -j1 --no-status
-  - catkin run_tests -p1 -j1
-  - catkin_test_results --all build
-  - catkin clean -b --yes
-  - catkin config --install
-  - catkin build -p1 -j1 --no-status
-after_failure:
-  - find ${HOME}/.ros/test_results -type f -exec echo "== {} ==" \; -exec cat {} \;
-  - for file in ${HOME}/.ros/log/rostest-*; do echo "=== $file ==="; cat $file; done
+  - ".industrial_ci/travis.sh"


### PR DESCRIPTION
This PR updates `.travis.yml` to test this repository on ROS kinetic/melodic instead of indigo/jade which are already EOL.