### PR TITLE
Fix theora plugin wrong path (#37)

### DIFF
--- a/theora_image_transport/theora_plugins.xml
+++ b/theora_image_transport/theora_plugins.xml
@@ -1,4 +1,4 @@
-<library path="lib/theora_image_transport">
+<library path="theora_image_transport_component">
   <class name="image_transport/theora_pub" type="theora_image_transport::TheoraPublisher" base_class_type="image_transport::PublisherPlugin">
     <description>
       This plugin publishes a video packet stream encoded using Theora.


### PR DESCRIPTION
The theora plugin defines its own message and to avoid a name conflict the library was called theora_image_transport_component instead of theora_image_transport.

However, this change was only done in the CMakeLists.txt and not in the theora_plugins.xml, making the loading of the plugin fail.

