### PR TITLE
Allow enabling/disabling of image publishing during operation.

### DIFF
--- a/compressed_depth_image_transport/cfg/CompressedDepthPublisher.cfg
+++ b/compressed_depth_image_transport/cfg/CompressedDepthPublisher.cfg
@@ -6,6 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
   
+gen.add("enable", bool_t, 0, "Enable image publishing", True)
 format_enum = gen.enum( [gen.const("png", str_t, "png", "PNG lossless compression"),
                          gen.const("rvl", str_t, "rvl", "RVL lossless compression")],
                         "Enum to set the compression format" )

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -73,6 +73,10 @@ void CompressedDepthPublisher::configCb(Config& config, uint32_t level)
 
 void CompressedDepthPublisher::publish(const sensor_msgs::Image& message, const PublishFn& publish_fn) const
 {
+  if (!config_.enable) {
+    return;
+  }
+
   sensor_msgs::CompressedImage::Ptr compressed_image =
       encodeCompressedDepthImage(message, config_.format, config_.depth_max, config_.depth_quantization, config_.png_level);
 

--- a/compressed_image_transport/cfg/CompressedPublisher.cfg
+++ b/compressed_image_transport/cfg/CompressedPublisher.cfg
@@ -6,6 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+gen.add("enable", bool_t, 0, "Enable image publishing", True)
 format_enum = gen.enum( [gen.const("jpeg", str_t, "jpeg", "JPEG lossy compression"),
                          gen.const("png", str_t, "png", "PNG lossless compression")],
                         "Enum to set the compression format" )

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -78,6 +78,10 @@ void CompressedPublisher::configCb(Config& config, uint32_t level)
 
 void CompressedPublisher::publish(const sensor_msgs::Image& message, const PublishFn& publish_fn) const
 {
+  if (!config_.enable) {
+    return;
+  }
+
   // Compressed image message
   sensor_msgs::CompressedImage compressed;
   compressed.header = message.header;

--- a/theora_image_transport/cfg/TheoraPublisher.cfg
+++ b/theora_image_transport/cfg/TheoraPublisher.cfg
@@ -6,6 +6,7 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 
+gen.add("enable", bool_t, 0, "Enable image publishing", True)
 optimize_for_enum = gen.enum([ gen.const("Bitrate", int_t, 0, "Aim for requested bitrate"),
                                gen.const("Quality", int_t, 1, "Aim for requested quality") ],
                              "Enum to control whether optimizing for bitrate or quality")

--- a/theora_image_transport/include/theora_image_transport/theora_publisher.h
+++ b/theora_image_transport/include/theora_image_transport/theora_publisher.h
@@ -73,6 +73,7 @@ protected:
   typedef theora_image_transport::TheoraPublisherConfig Config;
   typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
   boost::shared_ptr<ReconfigureServer> reconfigure_server_;
+  Config config_;
 
   void configCb(Config& config, uint32_t level);
 

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -135,6 +135,7 @@ void TheoraPublisher::configCb(Config& config, uint32_t level)
       config.keyframe_frequency = keyframe_frequency_; // In case desired value was unattainable
     }
   }
+  config_ = config;
 }
 
 void TheoraPublisher::connectCallback(const ros::SingleSubscriberPublisher& pub)
@@ -155,6 +156,10 @@ static void cvToTheoraPlane(cv::Mat& mat, th_img_plane& plane)
 
 void TheoraPublisher::publish(const sensor_msgs::Image& message, const PublishFn& publish_fn) const
 {
+  if (!config_.enable) {
+    return;
+  }
+
   if (!ensureEncodingContext(message, publish_fn))
     return;
   //return;


### PR DESCRIPTION
Add an enable bool to the publish dynamic reconfigure cfg files.  It defaults to true, but can interactively stop publishes perhaps to save cpu or bandwidth while running.