### PR TITLE
Add depth compression by RVL

### DIFF
--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -20,7 +20,7 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME} src/compressed_depth_publisher.cpp src/compressed_depth_subscriber.cpp src/manifest.cpp src/codec.cpp)
+add_library(${PROJECT_NAME} src/compressed_depth_publisher.cpp src/compressed_depth_subscriber.cpp src/manifest.cpp src/codec.cpp src/rvl_codec.cpp)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 

--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -20,7 +20,8 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME} src/compressed_depth_publisher.cpp src/compressed_depth_subscriber.cpp src/manifest.cpp src/codec.cpp src/rvl_codec.cpp)
+set(SOURCE_FILES src/compressed_depth_publisher.cpp src/compressed_depth_subscriber.cpp src/manifest.cpp src/codec.cpp src/rvl_codec.cpp)
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
@@ -39,3 +40,13 @@ install(DIRECTORY include/${PROJECT_NAME}/
 install(FILES compressed_depth_plugins.xml
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  # Build ${PROJECT_NAME}_test library with symbols exported.
+  add_library(${PROJECT_NAME}_test ${SOURCE_FILES})
+  add_dependencies(${PROJECT_NAME}_test ${PROJECT_NAME}_gencfg)
+  target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+
+  catkin_add_gtest(rvl_codec_test test/rvl_codec_test.cpp)
+  target_link_libraries(rvl_codec_test ${PROJECT_NAME}_test)
+endif()

--- a/compressed_depth_image_transport/cfg/CompressedDepthPublisher.cfg
+++ b/compressed_depth_image_transport/cfg/CompressedDepthPublisher.cfg
@@ -6,6 +6,11 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
   
+format_enum = gen.enum( [gen.const("png", str_t, "png", "PNG lossless compression"),
+                         gen.const("rvl", str_t, "rvl", "RVL lossless compression")],
+                        "Enum to set the compression format" )
+
+gen.add("format", str_t, 0, "Compression format", "png", edit_method = format_enum)
 gen.add("depth_max", double_t, 0, "Maximum depth value (meter) ", 10 , 1, 100)
 gen.add("depth_quantization", double_t, 0, "Depth value at which the sensor accuracy is 1 m (Kinect: >75)", 100, 1, 150)
 gen.add("png_level", int_t, 0, "PNG compression level", 9, 1, 9)

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
@@ -46,10 +46,10 @@ namespace compressed_depth_image_transport
 // Returns a null pointer on bad input.
 sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::CompressedImage& compressed_image);
 
-// Compress a depth image. The png_compression parameter is passed straight through to
-// OpenCV as IMWRITE_PNG_COMPRESSION. Returns a null pointer on bad input.
+// Compress a depth image. Returns a null pointer on bad input.
 sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
     const sensor_msgs::Image& message,
+    const std::string& compression_format,
     double depth_max,
     double depth_quantization,
     int png_level);

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
@@ -1,0 +1,13 @@
+// This file contains a modified copy of the code published by Andrew D. Wilson
+// in "Fast Lossless Depth Image Compression" in the proceedings of SIGCHI 2017.
+// The original code is licensed under the MIT License.
+
+class RvlCodec {
+  public:
+  int CompressRVL(const short* input, char* output, int numPixels);
+  void DecompressRVL(const char* input, short* output, int numPixels);
+  private:
+    void EncodeVLE(int value);
+    int DecodeVLE();
+    int *buffer, *pBuffer, word, nibblesWritten;
+};

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
@@ -5,15 +5,23 @@ namespace compressed_depth_image_transport {
 
 class RvlCodec {
  public:
+  RvlCodec();
   int CompressRVL(const unsigned short* input, unsigned char* output,
                   int numPixels);
   void DecompressRVL(const unsigned char* input, unsigned short* output,
                      int numPixels);
 
  private:
+  RvlCodec(const RvlCodec&);
+  RvlCodec& operator=(const RvlCodec&);
+
   void EncodeVLE(int value);
   int DecodeVLE();
-  int *buffer, *pBuffer, word, nibblesWritten;
+
+  int *buffer_;
+  int *pBuffer_;
+  int word_;
+  int nibblesWritten_;
 };
 
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
@@ -1,13 +1,21 @@
-// This file contains a modified copy of the code published by Andrew D. Wilson
-// in "Fast Lossless Depth Image Compression" in the proceedings of SIGCHI 2017.
-// The original code is licensed under the MIT License.
+#ifndef COMPRESSED_DEPTH_IMAGE_TRANSPORT_RVL_CODEC_H_
+#define COMPRESSED_DEPTH_IMAGE_TRANSPORT_RVL_CODEC_H_
+
+namespace compressed_depth_image_transport {
 
 class RvlCodec {
-  public:
-  int CompressRVL(const short* input, char* output, int numPixels);
-  void DecompressRVL(const char* input, short* output, int numPixels);
-  private:
-    void EncodeVLE(int value);
-    int DecodeVLE();
-    int *buffer, *pBuffer, word, nibblesWritten;
+ public:
+  int CompressRVL(const unsigned short* input, unsigned char* output,
+                  int numPixels);
+  void DecompressRVL(const unsigned char* input, unsigned short* output,
+                     int numPixels);
+
+ private:
+  void EncodeVLE(int value);
+  int DecodeVLE();
+  int *buffer, *pBuffer, word, nibblesWritten;
 };
+
+}  // namespace compressed_depth_image_transport
+
+#endif  // COMPRESSED_DEPTH_IMAGE_TRANSPORT_RVL_CODEC_H_

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
@@ -6,8 +6,12 @@ namespace compressed_depth_image_transport {
 class RvlCodec {
  public:
   RvlCodec();
+  // Compress input data into output. The size of output can be equal to
+  // (1.5 * numPixels + 4) in the worst case.
   int CompressRVL(const unsigned short* input, unsigned char* output,
                   int numPixels);
+  // Decompress input data into output. The size of output must be
+  // equal to numPixels.
   void DecompressRVL(const unsigned char* input, unsigned short* output,
                      int numPixels);
 

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -123,13 +123,13 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
           return sensor_msgs::Image::Ptr();
         }
       } else if (compression_format == "rvl") {
-        const char *buffer = reinterpret_cast<const char *>(&imageData[0]);
+        const unsigned char *buffer = reinterpret_cast<const unsigned char *>(&imageData[0]);
         uint32_t cols, rows;
         memcpy(&cols, &buffer[0], 4);
         memcpy(&rows, &buffer[4], 4);
         decompressed = Mat(rows, cols, CV_16UC1);
         RvlCodec rvl;
-        rvl.DecompressRVL(&buffer[8], decompressed.ptr<short>(), cols * rows);
+        rvl.DecompressRVL(&buffer[8], decompressed.ptr<unsigned short>(), cols * rows);
       } else {
         return nullptr;
       }
@@ -178,13 +178,13 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
           return sensor_msgs::Image::Ptr();
         }
       } else if (compression_format == "rvl") {
-        const char *buffer = reinterpret_cast<const char *>(&imageData[0]);
+        const unsigned char *buffer = reinterpret_cast<const unsigned char *>(&imageData[0]);
         uint32_t cols, rows;
         memcpy(&cols, &buffer[0], 4);
         memcpy(&rows, &buffer[4], 4);
         cv_ptr->image = Mat(rows, cols, CV_16UC1);
         RvlCodec rvl;
-        rvl.DecompressRVL(&buffer[8], cv_ptr->image.ptr<short>(), cols * rows);
+        rvl.DecompressRVL(&buffer[8], cv_ptr->image.ptr<unsigned short>(), cols * rows);
       } else {
         return nullptr;
       }
@@ -312,14 +312,14 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
         }
       } else if (compression_format == "rvl") {
         int numPixels = invDepthImg.rows * invDepthImg.cols;
-        // TODO: The size of data can increase after compression.
-        compressedImage.resize(numPixels);
+        // In the worst case, RVL compression results in 1.5x larger data.
+        compressedImage.resize(3 * numPixels);
         uint32_t cols = invDepthImg.cols;
         uint32_t rows = invDepthImg.rows;
         memcpy(&compressedImage[0], &cols, 4);
         memcpy(&compressedImage[4], &rows, 4);
         RvlCodec rvl;
-        int compressedSize = rvl.CompressRVL(invDepthImg.ptr<short>(), reinterpret_cast<char *>(&compressedImage[8]), numPixels);
+        int compressedSize = rvl.CompressRVL(invDepthImg.ptr<unsigned short>(), reinterpret_cast<unsigned char *>(&compressedImage[8]), numPixels);
         compressedImage.resize(8 + compressedSize);
       }
     }
@@ -373,14 +373,14 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
         }
       } else if (compression_format == "rvl") {
         int numPixels = cv_ptr->image.rows * cv_ptr->image.cols;
-        // TODO: The size of data can increase after compression.
-        compressedImage.resize(2 * numPixels);
+        // In the worst case, RVL compression results in 1.5x larger data.
+        compressedImage.resize(3 * numPixels);
         uint32_t cols = cv_ptr->image.cols;
         uint32_t rows = cv_ptr->image.rows;
         memcpy(&compressedImage[0], &cols, 4);
         memcpy(&compressedImage[4], &rows, 4);
         RvlCodec rvl;
-        int compressedSize = rvl.CompressRVL(cv_ptr->image.ptr<short>(), reinterpret_cast<char *>(&compressedImage[8]), numPixels);
+        int compressedSize = rvl.CompressRVL(cv_ptr->image.ptr<unsigned short>(), reinterpret_cast<unsigned char *>(&compressedImage[8]), numPixels);
         compressedImage.resize(8 + compressedSize);
       }
     }

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -123,7 +123,7 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
           return sensor_msgs::Image::Ptr();
         }
       } else if (compression_format == "rvl") {
-        const unsigned char *buffer = reinterpret_cast<const unsigned char *>(&imageData[0]);
+        const unsigned char *buffer = imageData.data();
         uint32_t cols, rows;
         memcpy(&cols, &buffer[0], 4);
         memcpy(&rows, &buffer[4], 4);
@@ -178,7 +178,7 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
           return sensor_msgs::Image::Ptr();
         }
       } else if (compression_format == "rvl") {
-        const unsigned char *buffer = reinterpret_cast<const unsigned char *>(&imageData[0]);
+        const unsigned char *buffer = imageData.data();
         uint32_t cols, rows;
         memcpy(&cols, &buffer[0], 4);
         memcpy(&rows, &buffer[4], 4);
@@ -319,7 +319,7 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
         memcpy(&compressedImage[0], &cols, 4);
         memcpy(&compressedImage[4], &rows, 4);
         RvlCodec rvl;
-        int compressedSize = rvl.CompressRVL(invDepthImg.ptr<unsigned short>(), reinterpret_cast<unsigned char *>(&compressedImage[8]), numPixels);
+        int compressedSize = rvl.CompressRVL(invDepthImg.ptr<unsigned short>(), &compressedImage[8], numPixels);
         compressedImage.resize(8 + compressedSize);
       }
     }
@@ -380,7 +380,7 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
         memcpy(&compressedImage[0], &cols, 4);
         memcpy(&compressedImage[4], &rows, 4);
         RvlCodec rvl;
-        int compressedSize = rvl.CompressRVL(cv_ptr->image.ptr<unsigned short>(), reinterpret_cast<unsigned char *>(&compressedImage[8]), numPixels);
+        int compressedSize = rvl.CompressRVL(cv_ptr->image.ptr<unsigned short>(), &compressedImage[8], numPixels);
         compressedImage.resize(8 + compressedSize);
       }
     }

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -84,7 +84,7 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
       compression_format = "rvl";
     } else {
       ROS_ERROR("Unsupported image format: %s", message.format.c_str());
-      return nullptr;
+      return sensor_msgs::Image::Ptr();
     }
   }
 
@@ -131,7 +131,7 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
         RvlCodec rvl;
         rvl.DecompressRVL(&buffer[8], decompressed.ptr<unsigned short>(), cols * rows);
       } else {
-        return nullptr;
+        return sensor_msgs::Image::Ptr();
       }
 
       size_t rows = decompressed.rows;
@@ -186,7 +186,7 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
         RvlCodec rvl;
         rvl.DecompressRVL(&buffer[8], cv_ptr->image.ptr<unsigned short>(), cols * rows);
       } else {
-        return nullptr;
+        return sensor_msgs::Image::Ptr();
       }
 
       size_t rows = cv_ptr->image.rows;

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -312,8 +312,8 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
         }
       } else if (compression_format == "rvl") {
         int numPixels = invDepthImg.rows * invDepthImg.cols;
-        // In the worst case, RVL compression results in 1.5x larger data.
-        compressedImage.resize(3 * numPixels);
+        // In the worst case, RVL compression results in ~1.5x larger data.
+        compressedImage.resize(3 * numPixels + 12);
         uint32_t cols = invDepthImg.cols;
         uint32_t rows = invDepthImg.rows;
         memcpy(&compressedImage[0], &cols, 4);
@@ -373,8 +373,8 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
         }
       } else if (compression_format == "rvl") {
         int numPixels = cv_ptr->image.rows * cv_ptr->image.cols;
-        // In the worst case, RVL compression results in 1.5x larger data.
-        compressedImage.resize(3 * numPixels);
+        // In the worst case, RVL compression results in ~1.5x larger data.
+        compressedImage.resize(3 * numPixels + 12);
         uint32_t cols = cv_ptr->image.cols;
         uint32_t rows = cv_ptr->image.rows;
         memcpy(&compressedImage[0], &cols, 4);

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -74,7 +74,7 @@ void CompressedDepthPublisher::configCb(Config& config, uint32_t level)
 void CompressedDepthPublisher::publish(const sensor_msgs::Image& message, const PublishFn& publish_fn) const
 {
   sensor_msgs::CompressedImage::Ptr compressed_image =
-      encodeCompressedDepthImage(message, config_.depth_max, config_.depth_quantization, config_.png_level);
+      encodeCompressedDepthImage(message, config_.format, config_.depth_max, config_.depth_quantization, config_.png_level);
 
   if (compressed_image)
   {

--- a/compressed_depth_image_transport/src/rvl_codec.cpp
+++ b/compressed_depth_image_transport/src/rvl_codec.cpp
@@ -1,0 +1,82 @@
+// This file contains a modified copy of the code published by Andrew D. Wilson
+// in "Fast Lossless Depth Image Compression" in the proceedings of SIGCHI 2017.
+// The original code is licensed under the MIT License.
+
+#include "compressed_depth_image_transport/rvl_codec.h"
+
+void RvlCodec::EncodeVLE(int value) {
+  do {
+    int nibble = value & 0x7;        // lower 3 bits
+    if (value >>= 3) nibble |= 0x8;  // more to come
+    word <<= 4;
+    word |= nibble;
+    if (++nibblesWritten == 8)  // output word
+    {
+      *pBuffer++ = word;
+      nibblesWritten = 0;
+      word = 0;
+    }
+  } while (value);
+}
+
+int RvlCodec::DecodeVLE() {
+  unsigned int nibble;
+  int value = 0, bits = 29;
+  do {
+    if (!nibblesWritten) {
+      word = *pBuffer++;  // load word
+      nibblesWritten = 8;
+    }
+    nibble = word & 0xf0000000;
+    value |= (nibble << 1) >> bits;
+    word <<= 4;
+    nibblesWritten--;
+    bits -= 3;
+  } while (nibble & 0x80000000);
+  return value;
+}
+
+int RvlCodec::CompressRVL(const short* input, char* output, int numPixels) {
+  buffer = pBuffer = (int*)output;
+  nibblesWritten = 0;
+  const short* end = input + numPixels;
+  short previous = 0;
+  while (input != end) {
+    int zeros = 0, nonzeros = 0;
+    for (; (input != end) && !*input; input++, zeros++);
+    EncodeVLE(zeros);  // number of zeros
+    for (const short* p = input; (p != end) && *p++; nonzeros++);
+    EncodeVLE(nonzeros);  // number of nonzeros
+    for (int i = 0; i < nonzeros; i++) {
+      short current = *input++;
+      int delta = current - previous;
+      int positive = (delta << 1) ^ (delta >> 31);
+      EncodeVLE(positive);  // nonzero value
+      previous = current;
+    }
+  }
+  if (nibblesWritten)  // last few values
+    *pBuffer++ = word << 4 * (8 - nibblesWritten);
+  return int((char*)pBuffer - (char*)buffer);  // num bytes
+}
+
+void RvlCodec::DecompressRVL(const char* input, short* output, int numPixels) {
+  buffer = pBuffer = const_cast<int*>(reinterpret_cast<const int*>(input));
+  nibblesWritten = 0;
+  short current, previous = 0;
+  int numPixelsToDecode = numPixels;
+  while (numPixelsToDecode) {
+    int zeros = DecodeVLE();  // number of zeros
+    numPixelsToDecode -= zeros;
+    for (; zeros; zeros--) *output++ = 0;
+    int nonzeros = DecodeVLE();  // number of nonzeros
+    numPixelsToDecode -= nonzeros;
+    for (; nonzeros; nonzeros--) {
+      int positive = DecodeVLE();  // nonzero value
+      int delta = (positive >> 1) ^ -(positive & 1);
+      current = previous + delta;
+      *output++ = current;
+      previous = current;
+    }
+  }
+}

--- a/compressed_depth_image_transport/test/rvl_codec_test.cpp
+++ b/compressed_depth_image_transport/test/rvl_codec_test.cpp
@@ -23,13 +23,6 @@ TEST(RvlCodecTest, reciprocalTestEmpty) {
   rvl.DecompressRVL(&compressed[0], &decompressed[0], size);
   EXPECT_TRUE(std::equal(original.begin(), original.end(), decompressed.begin()));
 
-  for (int i = 0; i < size; ++i) {
-    original[i] = rand() % std::numeric_limits<unsigned short>::max();
-  }
-  for (int i = 0; i < size; ++i) {
-    original[rand() % size] = 0;
-  }
-
   // Empty depth.
   EXPECT_EQ(rvl.CompressRVL(NULL, NULL, 0), 0);
   rvl.DecompressRVL(NULL, NULL, 0);  // should not die.

--- a/compressed_depth_image_transport/test/rvl_codec_test.cpp
+++ b/compressed_depth_image_transport/test/rvl_codec_test.cpp
@@ -24,7 +24,7 @@ TEST(RvlCodecTest, reciprocalTestEmpty) {
   EXPECT_TRUE(std::equal(original.begin(), original.end(), decompressed.begin()));
 
   for (int i = 0; i < size; ++i) {
-    original[i] = rand() % std::numeric_limits<uint16_t>::max();
+    original[i] = rand() % std::numeric_limits<unsigned short>::max();
   }
   for (int i = 0; i < size; ++i) {
     original[rand() % size] = 0;

--- a/compressed_depth_image_transport/test/rvl_codec_test.cpp
+++ b/compressed_depth_image_transport/test/rvl_codec_test.cpp
@@ -31,8 +31,8 @@ TEST(RvlCodecTest, reciprocalTestEmpty) {
   }
 
   // Empty depth.
-  EXPECT_EQ(rvl.CompressRVL(nullptr, nullptr, 0), 0);
-  rvl.DecompressRVL(nullptr, nullptr, 0);  // should not die.
+  EXPECT_EQ(rvl.CompressRVL(NULL, NULL, 0), 0);
+  rvl.DecompressRVL(NULL, NULL, 0);  // should not die.
 }
 
 TEST(RvlCodecTest, reciprocalTestRandom) {

--- a/compressed_depth_image_transport/test/rvl_codec_test.cpp
+++ b/compressed_depth_image_transport/test/rvl_codec_test.cpp
@@ -4,8 +4,7 @@
 TEST(RvlCodecTest, reciprocalTestEmpty) {
   const int size = 1000000;
   std::vector<unsigned short> original(size);
-  // In the worst case, RVL compression results in 1.5x larger data.
-  std::vector<unsigned char> compressed(3 * size);
+  std::vector<unsigned char> compressed(3 * size + 4);
   std::vector<unsigned short> decompressed(size);
   compressed_depth_image_transport::RvlCodec rvl;
 
@@ -31,12 +30,11 @@ TEST(RvlCodecTest, reciprocalTestEmpty) {
 TEST(RvlCodecTest, reciprocalTestRandom) {
   const int size = 1000000;
   std::vector<unsigned short> original(size);
-  // In the worst case, RVL compression results in 1.5x larger data.
-  std::vector<unsigned char> compressed(3 * size);
+  std::vector<unsigned char> compressed(3 * size + 4);
   std::vector<unsigned short> decompressed(size);
   compressed_depth_image_transport::RvlCodec rvl;
 
-  // Initialize with random size of runs with random values.
+  // Populate depths with random size of runs with random values.
   for (int i = 0; i < size;) {
     int length = std::min<int>(rand() % 10, size - i);
     int value = rand() % 10;

--- a/compressed_depth_image_transport/test/rvl_codec_test.cpp
+++ b/compressed_depth_image_transport/test/rvl_codec_test.cpp
@@ -1,0 +1,65 @@
+#include "compressed_depth_image_transport/rvl_codec.h"
+#include <gtest/gtest.h>
+
+TEST(RvlCodecTest, reciprocalTestEmpty) {
+  const int size = 1000000;
+  std::vector<unsigned short> original(size);
+  // In the worst case, RVL compression results in 1.5x larger data.
+  std::vector<unsigned char> compressed(3 * size);
+  std::vector<unsigned short> decompressed(size);
+  compressed_depth_image_transport::RvlCodec rvl;
+
+  // Constant depth.
+  const int validDepth = 42;
+  std::fill(original.begin(), original.end(), validDepth);
+  rvl.CompressRVL(&original[0], &compressed[0], size);
+  rvl.DecompressRVL(&compressed[0], &decompressed[0], size);
+  EXPECT_TRUE(std::equal(original.begin(), original.end(), decompressed.begin()));
+
+  // Totally invalid depth.
+  const int invalidDepth = 0;
+  std::fill(original.begin(), original.end(), invalidDepth);
+  rvl.CompressRVL(&original[0], &compressed[0], size);
+  rvl.DecompressRVL(&compressed[0], &decompressed[0], size);
+  EXPECT_TRUE(std::equal(original.begin(), original.end(), decompressed.begin()));
+
+  for (int i = 0; i < size; ++i) {
+    original[i] = rand() % std::numeric_limits<uint16_t>::max();
+  }
+  for (int i = 0; i < size; ++i) {
+    original[rand() % size] = 0;
+  }
+
+  // Empty depth.
+  EXPECT_EQ(rvl.CompressRVL(nullptr, nullptr, 0), 0);
+  rvl.DecompressRVL(nullptr, nullptr, 0);  // should not die.
+}
+
+TEST(RvlCodecTest, reciprocalTestRandom) {
+  const int size = 1000000;
+  std::vector<unsigned short> original(size);
+  // In the worst case, RVL compression results in 1.5x larger data.
+  std::vector<unsigned char> compressed(3 * size);
+  std::vector<unsigned short> decompressed(size);
+  compressed_depth_image_transport::RvlCodec rvl;
+
+  // Initialize with random size of runs with random values.
+  for (int i = 0; i < size;) {
+    int length = std::min<int>(rand() % 10, size - i);
+    int value = rand() % 10;
+    std::fill(&original[i], &original[i] + length, value);
+    i += length;
+  }
+
+  const int compressedSize =
+      rvl.CompressRVL(&original[0], &compressed[0], size);
+  EXPECT_GT(compressedSize, 0);
+  EXPECT_LT(compressedSize, compressed.size());
+  rvl.DecompressRVL(&compressed[0], &decompressed[0], size);
+  EXPECT_TRUE(std::equal(original.begin(), original.end(), decompressed.begin()));
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
A lossless depth compression scheme, RVL, is added to compressed_depth_image_transform. 
RVL is a compression method proposed by Andrew D. Wilson in "Fast Lossless Depth Image Compression" at SIGCHI 2017. It has several advantages over PNG including:

- Compression is 7-8 times faster. Depth in VGA resolution can easily be compressed at 30Hz on a standard PC.
- Decompression is 2+ times faster.
- Compression ratio is reportedly comparable to PNG and Lossless-JPEG.