### PR TITLE
Use non-deprecated image_transport headers

### DIFF
--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -38,7 +38,7 @@
 #include <vector>
 
 #include "cv_bridge/cv_bridge.h"
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <rclcpp/logging.hpp>
 
 #include "compressed_depth_image_transport/codec.h"
@@ -138,7 +138,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
       // Decode raw image
       try
       {
-        cv_ptr->image = cv::imdecode(imageData, CV_LOAD_IMAGE_UNCHANGED);
+        cv_ptr->image = cv::imdecode(imageData, cv::IMREAD_UNCHANGED);
       }
       catch (cv::Exception& e)
       {

--- a/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
@@ -36,7 +36,7 @@
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
-#include "image_transport/simple_publisher_plugin.h"
+#include <image_transport/simple_publisher_plugin.hpp>
 
 #include <rclcpp/node.hpp>
 

--- a/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
@@ -38,8 +38,7 @@
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
-
-#include "image_transport/simple_subscriber_plugin.h"
+#include <image_transport/simple_subscriber_plugin.hpp>
 
 namespace compressed_image_transport {
 

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -36,7 +36,7 @@
 
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.hpp>
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 #include "compressed_image_transport/compression_common.h"
 
@@ -126,7 +126,7 @@ void CompressedPublisher::publish(
     // JPEG Compression
     case JPEG:
     {
-      params[0] = CV_IMWRITE_JPEG_QUALITY;
+      params[0] = cv::IMWRITE_JPEG_QUALITY;
       params[1] = config_.jpeg_quality;
 
       // Update ros message format header
@@ -184,7 +184,7 @@ void CompressedPublisher::publish(
       // PNG Compression
     case PNG:
     {
-      params[0] = CV_IMWRITE_PNG_COMPRESSION;
+      params[0] = cv::IMWRITE_PNG_COMPRESSION;
       params[1] = config_.png_level;
 
       // Update ros message format header


### PR DESCRIPTION
Signed-off-by: Michael Carroll <michael@openrobotics.org>