### PR TITLE
Fix #63, regression in compressed_depth_image_transport with old bags

### DIFF
--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -82,6 +82,8 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
       compression_format = "png";
     } else if (format.find("compressedDepth rvl") != std::string::npos) {
       compression_format = "rvl";
+    } else if (format.find("compressedDepth") != std::string::npos && format.find("compressedDepth ") == std::string::npos) {
+      compression_format = "png";
     } else {
       ROS_ERROR("Unsupported image format: %s", message.format.c_str());
       return sensor_msgs::Image::Ptr();


### PR DESCRIPTION
Adding this else-if clause fixes the error `Unsupported image format: 16UC1; compressedDepth` when playing existing bagfiles. The regression had been introduced in commit a710d4abab2d2 in the `noetic-devel` branch by not correctly checking for old format strings.