### PR TITLE
Fix ament_export_dependencies syntax in CMake

### DIFF
--- a/theora_image_transport/CMakeLists.txt
+++ b/theora_image_transport/CMakeLists.txt
@@ -94,12 +94,8 @@ rosidl_target_interfaces(ogg_saver
   ${PROJECT_NAME} "rosidl_typesupport_cpp") 
 
 ament_export_dependencies(rosidl_default_runtime
-  ${OpenCV_LIBRARIES}
-  ${PC_OGG_LIBRARIES}
-  ${PC_THEORA_LIBRARIES}
-  ${PC_THEORAENC_LIBRARIES}
-  ${PC_THEORADEC_LIBRARIES}
-  ${LIBRARY_NAME})
+  OpenCV
+  PkgConfig)
 
 install(TARGETS ${LIBRARY_NAME} ogg_saver
   ARCHIVE DESTINATION lib/${PROJECT_NAME}


### PR DESCRIPTION
Signed-off-by: Chen Bainian <chenbn@artc.a-star.edu.sg>

Fix #62 

I am not sure this is the best way to fix the error.

I think it will be good if after this PR is settled, a new release can be made, so that the `theora_image_transport` binary won't break `ros1_bridge`'s build from source in Foxy.