### PR TITLE
[ros2] Fix RCLCPP_* logs, a string literal must be the first argument

### DIFF
--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -81,7 +81,7 @@ void CompressedPublisher::advertiseImpl(
   }
   else
   {
-    RCLCPP_WARN(logger_, format_param_name + " was previously delared");
+    RCLCPP_WARN(logger_, "%s was previously declared", format_param_name.c_str());
   }
 
   std::string png_level_param_name = param_base_name + ".png_level";
@@ -101,7 +101,7 @@ void CompressedPublisher::advertiseImpl(
   }
   else
   {
-    RCLCPP_WARN(logger_, png_level_param_name + " was previously delared");
+    RCLCPP_WARN(logger_, "%s was previously delared", png_level_param_name.c_str());
   }
 
   std::string jpeg_quality_param_name = param_base_name + ".jpeg_quality";
@@ -121,7 +121,7 @@ void CompressedPublisher::advertiseImpl(
   }
   else
   {
-    RCLCPP_WARN(logger_, jpeg_quality_param_name + " was previously delared");
+    RCLCPP_WARN(logger_, "%s was previously delared", jpeg_quality_param_name);
   }
 }
 

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -121,7 +121,7 @@ void CompressedPublisher::advertiseImpl(
   }
   else
   {
-    RCLCPP_WARN(logger_, "%s was previously delared", jpeg_quality_param_name);
+    RCLCPP_WARN(logger_, "%s was previously delared", jpeg_quality_param_name.c_str());
   }
 }
 


### PR DESCRIPTION
The `ros2` branch doesn't compile with neither rolling or galactic.
This PR fixes it.