### PR TITLE
Fix for galactic

### DIFF
--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -81,7 +81,7 @@ void CompressedPublisher::advertiseImpl(
   }
   else
   {
-    RCLCPP_WARN(logger_, format_param_name + " was previously delared");
+    RCLCPP_WARN_STREAM(logger_, format_param_name << " was previously delared");
   }
 
   std::string png_level_param_name = param_base_name + ".png_level";
@@ -101,7 +101,7 @@ void CompressedPublisher::advertiseImpl(
   }
   else
   {
-    RCLCPP_WARN(logger_, png_level_param_name + " was previously delared");
+    RCLCPP_WARN_STREAM(logger_, png_level_param_name << " was previously delared");
   }
 
   std::string jpeg_quality_param_name = param_base_name + ".jpeg_quality";
@@ -121,7 +121,7 @@ void CompressedPublisher::advertiseImpl(
   }
   else
   {
-    RCLCPP_WARN(logger_, jpeg_quality_param_name + " was previously delared");
+    RCLCPP_WARN_STREAM(logger_, jpeg_quality_param_name << " was previously delared");
   }
 }
 


### PR DESCRIPTION
This fixes build errors in `galactic` as below.
```
--- stderr: compressed_image_transport                                                                                      
In file included from /opt/ros/galactic/include/rclcpp/client.hpp:40,
                 from /opt/ros/galactic/include/rclcpp/callback_group.hpp:23,
                 from /opt/ros/galactic/include/rclcpp/node.hpp:40,
                 from /opt/ros/galactic/include/image_transport/simple_publisher_plugin.hpp:38,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h:39,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:35:
/home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp: In member function ‘virtual void compressed_image_transport::CompressedPublisher::advertiseImpl(rclcpp::Node*, const string&, rmw_qos_profile_t)’:
/home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:84:44: error: cannot convert ‘std::__cxx11::basic_string<char>’ to ‘const char*’
   84 |     RCLCPP_WARN(logger_, format_param_name + " was previously delared");
      |                          ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                            |
      |                                            std::__cxx11::basic_string<char>
In file included from /opt/ros/galactic/include/rmw/types.h:28,
                 from /opt/ros/galactic/include/rcl/types.h:20,
                 from /opt/ros/galactic/include/rcl/log_level.h:22,
                 from /opt/ros/galactic/include/rcl/arguments.h:21,
                 from /opt/ros/galactic/include/rcl/node.h:28,
                 from /opt/ros/galactic/include/rclcpp/node.hpp:33,
                 from /opt/ros/galactic/include/image_transport/simple_publisher_plugin.hpp:38,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h:39,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:35:
/opt/ros/galactic/include/rcutils/logging.h:479:16: note:   initializing argument 4 of ‘void rcutils_log(const rcutils_log_location_t*, int, const char*, const char*, ...)’
  479 |   const char * format,
      |   ~~~~~~~~~~~~~^~~~~~
In file included from /opt/ros/galactic/include/rclcpp/client.hpp:40,
                 from /opt/ros/galactic/include/rclcpp/callback_group.hpp:23,
                 from /opt/ros/galactic/include/rclcpp/node.hpp:40,
                 from /opt/ros/galactic/include/image_transport/simple_publisher_plugin.hpp:38,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h:39,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:35:
/home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:104:47: error: cannot convert ‘std::__cxx11::basic_string<char>’ to ‘const char*’
  104 |     RCLCPP_WARN(logger_, png_level_param_name + " was previously delared");
      |                          ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               std::__cxx11::basic_string<char>
In file included from /opt/ros/galactic/include/rmw/types.h:28,
                 from /opt/ros/galactic/include/rcl/types.h:20,
                 from /opt/ros/galactic/include/rcl/log_level.h:22,
                 from /opt/ros/galactic/include/rcl/arguments.h:21,
                 from /opt/ros/galactic/include/rcl/node.h:28,
                 from /opt/ros/galactic/include/rclcpp/node.hpp:33,
                 from /opt/ros/galactic/include/image_transport/simple_publisher_plugin.hpp:38,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h:39,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:35:
/opt/ros/galactic/include/rcutils/logging.h:479:16: note:   initializing argument 4 of ‘void rcutils_log(const rcutils_log_location_t*, int, const char*, const char*, ...)’
  479 |   const char * format,
      |   ~~~~~~~~~~~~~^~~~~~
In file included from /opt/ros/galactic/include/rclcpp/client.hpp:40,
                 from /opt/ros/galactic/include/rclcpp/callback_group.hpp:23,
                 from /opt/ros/galactic/include/rclcpp/node.hpp:40,
                 from /opt/ros/galactic/include/image_transport/simple_publisher_plugin.hpp:38,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h:39,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:35:
/home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:124:50: error: cannot convert ‘std::__cxx11::basic_string<char>’ to ‘const char*’
  124 |     RCLCPP_WARN(logger_, jpeg_quality_param_name + " was previously delared");
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                  |
      |                                                  std::__cxx11::basic_string<char>
In file included from /opt/ros/galactic/include/rmw/types.h:28,
                 from /opt/ros/galactic/include/rcl/types.h:20,
                 from /opt/ros/galactic/include/rcl/log_level.h:22,
                 from /opt/ros/galactic/include/rcl/arguments.h:21,
                 from /opt/ros/galactic/include/rcl/node.h:28,
                 from /opt/ros/galactic/include/rclcpp/node.hpp:33,
                 from /opt/ros/galactic/include/image_transport/simple_publisher_plugin.hpp:38,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h:39,
                 from /home/daisuke/workspace/autoware.proj.jpntaxi.rolling/src/vendor/image_transport_plugins/compressed_image_transport/src/compressed_publisher.cpp:35:
/opt/ros/galactic/include/rcutils/logging.h:479:16: note:   initializing argument 4 of ‘void rcutils_log(const rcutils_log_location_t*, int, const char*, const char*, ...)’
  479 |   const char * format,
```