### PR TITLE
Port parameter declared check compressed image transport subscription

### DIFF
--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -67,13 +67,27 @@ void CompressedSubscriber::subscribeImpl(
     typedef image_transport::SimpleSubscriberPlugin<CompressedImage> Base;
     Base::subscribeImpl(node, base_topic, callback, custom_qos);
     std::string mode;
-    rcl_interfaces::msg::ParameterDescriptor mode_description;
-    mode_description.name = "mode";
-    mode_description.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-    mode_description.description = "OpenCV imdecode flags to use";
-    mode_description.read_only = false;
-    mode_description.additional_constraints = "Supported values: [unchanged, gray, color]";
-    mode = node->declare_parameter("mode", kDefaultMode, mode_description);
+
+    uint ns_len = node->get_effective_namespace().length();
+    std::string param_base_name = base_topic.substr(ns_len);
+    std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+    std::string mode_param_name = param_base_name + ".mode";
+
+    if (!node->has_parameter(mode_param_name))
+    {
+      rcl_interfaces::msg::ParameterDescriptor mode_description;
+      mode_description.name = mode_param_name;
+      mode_description.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+      mode_description.description = "OpenCV imdecode flags to use";
+      mode_description.read_only = false;
+      mode_description.additional_constraints = "Supported values: [unchanged, gray, color]";
+      mode = node->declare_parameter(mode_param_name, kDefaultMode, mode_description);
+    }
+    else
+    {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", mode_param_name.c_str());
+      mode = node->get_parameter(mode_param_name).get_value<std::string>();
+    }
 
     if (mode == "unchanged") {
       config_.imdecode_flag = cv::IMREAD_UNCHANGED;


### PR DESCRIPTION
This fixes a bug where more than one compressed image subscription would fail due to the following exception.

`terminate called after throwing an instance of 'rclcpp::exceptions::ParameterAlreadyDeclaredException'
  what():  parameter 'mode' has already been declared
`
This has been fixed in future versions (galactic) but is not available for foxy.

