### PR TITLE
Ament export libraries

### DIFF
--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -50,4 +50,5 @@ install(
 pluginlib_export_plugin_description_file(image_transport
     compressed_depth_plugins.xml)
 
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/compressed_image_transport/CMakeLists.txt
+++ b/compressed_image_transport/CMakeLists.txt
@@ -52,4 +52,5 @@ install(
 )
 pluginlib_export_plugin_description_file(image_transport compressed_plugins.xml)
 
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/theora_image_transport/CMakeLists.txt
+++ b/theora_image_transport/CMakeLists.txt
@@ -120,4 +120,5 @@ install(
 
 pluginlib_export_plugin_description_file(image_transport theora_plugins.xml)
 
+ament_export_libraries(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
In order to properly use the packages under ROS2, a few ament_export_libraries calls are needed.
