### PR TITLE
Make the default compressed depth png_level 1 instead of 9 to save cpu

### DIFF
--- a/compressed_depth_image_transport/cfg/CompressedDepthPublisher.cfg
+++ b/compressed_depth_image_transport/cfg/CompressedDepthPublisher.cfg
@@ -13,7 +13,7 @@ format_enum = gen.enum( [gen.const("png", str_t, "png", "PNG lossless compressio
 gen.add("format", str_t, 0, "Compression format", "png", edit_method = format_enum)
 gen.add("depth_max", double_t, 0, "Maximum depth value (meter) ", 10 , 1, 100)
 gen.add("depth_quantization", double_t, 0, "Depth value at which the sensor accuracy is 1 m (Kinect: >75)", 100, 1, 150)
-gen.add("png_level", int_t, 0, "PNG compression level", 9, 1, 9)
+gen.add("png_level", int_t, 0, "PNG compression level", 1, 1, 9)
 
  
 exit(gen.generate(PACKAGE, "CompressedDepthPublisher", "CompressedDepthPublisher"))


### PR DESCRIPTION
The default 9 is so cpu intensive to be frequently unusable and results in many dropped frames, and there is still plenty of bandwidth savings from the compression at level 1.