### PR TITLE
fix: fix param base name which starts with '.'

### DIFF
--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -69,6 +69,7 @@ void CompressedPublisher::advertiseImpl(
   uint ns_len = node->get_effective_namespace().length();
   std::string param_base_name = base_topic.substr(ns_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  if (param_base_name.find(".") == 0) {param_base_name = param_base_name.substr(1);}
   std::string format_param_name = param_base_name + ".format";
   rcl_interfaces::msg::ParameterDescriptor format_description;
   format_description.name = "format";

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -69,7 +69,9 @@ void CompressedPublisher::advertiseImpl(
   uint ns_len = node->get_effective_namespace().length();
   std::string param_base_name = base_topic.substr(ns_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
-  if (param_base_name.find(".") == 0) {param_base_name = param_base_name.substr(1);}
+  if (param_base_name.find(".") == 0) {
+    param_base_name = param_base_name.substr(1);
+  }
   std::string format_param_name = param_base_name + ".format";
   rcl_interfaces::msg::ParameterDescriptor format_description;
   format_description.name = "format";


### PR DESCRIPTION
param base name which starts with '.' causes the problem for parameter as below.
```
❯ ros2 param dump /sensing/camera/camera1/rectify_node
/sensing/camera/camera1/rectify_node:
  ros__parameters:
    ? ''
    : image_rect:
        format: jpeg
        jpeg_quality: 95
        png_level: 3
    interpolation: 1
    qos_overrides:
      /parameter_events:
        publisher:
          depth: 1000
          durability: volatile
          history: keep_last
          reliability: reliable
    queue_size: 5
    use_sim_time: false
    use_system_default_qos: false
```