### PR TITLE
[rolling] Address deprecation warnings to fix build

### DIFF
--- a/theora_image_transport/CMakeLists.txt
+++ b/theora_image_transport/CMakeLists.txt
@@ -97,11 +97,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}
    ADD_LINTER_TESTS
 )
 
-rosidl_target_interfaces(${LIBRARY_NAME}
-  ${PROJECT_NAME} "rosidl_typesupport_cpp") 
-
-rosidl_target_interfaces(ogg_saver
-  ${PROJECT_NAME} "rosidl_typesupport_cpp") 
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(${LIBRARY_NAME}
+  "${cpp_typesupport_target}"
+)
+target_link_libraries(ogg_saver
+  "${cpp_typesupport_target}"
+)
 
 ament_export_dependencies(rosidl_default_runtime
   OpenCV


### PR DESCRIPTION
There was a CMake error when building from source with Rolling and addressing the deprecation warnings fixed it.
The error was cryptic, so I'm not sure exactly what was going wrong. Here it is for reference:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
/home/jacob/ws/src/ros-perception/image_transport_plugins/theora_image_transport/include_directories
   used as include directory in directory /home/jacob/ws/src/ros-perception/image_transport_plugins/theora_image_transport
   used as include directory in directory /home/jacob/ws/src/ros-perception/image_transport_plugins/theora_image_transport
```