### PR TITLE
use boost::placeholders::_1/_2

### DIFF
--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -62,7 +62,8 @@ void CompressedDepthPublisher::advertiseImpl(ros::NodeHandle &nh, const std::str
 
   // Set up reconfigure server for this topic
   reconfigure_server_ = boost::make_shared<ReconfigureServer>(this->nh());
-  ReconfigureServer::CallbackType f = boost::bind(&CompressedDepthPublisher::configCb, this, _1, _2);
+  ReconfigureServer::CallbackType f = boost::bind(&CompressedDepthPublisher::configCb, this,
+      boost::placeholders::_1, boost::placeholders::_2);
   reconfigure_server_->setCallback(f);
 }
 

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -67,7 +67,8 @@ void CompressedPublisher::advertiseImpl(ros::NodeHandle &nh, const std::string &
 
   // Set up reconfigure server for this topic
   reconfigure_server_ = boost::make_shared<ReconfigureServer>(this->nh());
-  ReconfigureServer::CallbackType f = boost::bind(&CompressedPublisher::configCb, this, _1, _2);
+  ReconfigureServer::CallbackType f = boost::bind(&CompressedPublisher::configCb, this,
+      boost::placeholders::_1, boost::placeholders::_2);
   reconfigure_server_->setCallback(f);
 }
 

--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -59,7 +59,8 @@ void CompressedSubscriber::subscribeImpl(ros::NodeHandle& nh, const std::string&
 
     // Set up reconfigure server for this topic
     reconfigure_server_ = boost::make_shared<ReconfigureServer>(this->nh());
-    ReconfigureServer::CallbackType f = boost::bind(&CompressedSubscriber::configCb, this, _1, _2);
+    ReconfigureServer::CallbackType f = boost::bind(&CompressedSubscriber::configCb, this,
+        boost::placeholders::_1, boost::placeholders::_2);
     reconfigure_server_->setCallback(f);
 }
 

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -84,7 +84,8 @@ void TheoraPublisher::advertiseImpl(ros::NodeHandle &nh, const std::string &base
 
   // Set up reconfigure server for this topic
   reconfigure_server_ = boost::make_shared<ReconfigureServer>(this->nh());
-  ReconfigureServer::CallbackType f = boost::bind(&TheoraPublisher::configCb, this, _1, _2);
+  ReconfigureServer::CallbackType f = boost::bind(&TheoraPublisher::configCb, this,
+      boost::placeholders::_1, boost::placeholders::_2);
   reconfigure_server_->setCallback(f);
 }
 

--- a/theora_image_transport/src/theora_subscriber.cpp
+++ b/theora_image_transport/src/theora_subscriber.cpp
@@ -73,7 +73,8 @@ void TheoraSubscriber::subscribeImpl(ros::NodeHandle &nh, const std::string &bas
 
   // Set up reconfigure server for this topic
   reconfigure_server_ = boost::make_shared<ReconfigureServer>(this->nh());
-  ReconfigureServer::CallbackType f = boost::bind(&TheoraSubscriber::configCb, this, _1, _2);
+  ReconfigureServer::CallbackType f = boost::bind(&TheoraSubscriber::configCb, this,
+      boost::placeholders::_1, boost::placeholders::_2);
   reconfigure_server_->setCallback(f);
 }
 


### PR DESCRIPTION
Use boost::placeholders::_1/_2 instead of the globally namespaced _1/_2 (which are deprecated)