### PR TITLE
Adding QOI compression support to ROS2

### DIFF
--- a/compressed_image_transport/CMakeLists.txt
+++ b/compressed_image_transport/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
   src/compressed_publisher.cpp
   src/compressed_subscriber.cpp
   src/manifest.cpp
+  src/qoi.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})

--- a/compressed_image_transport/cfg/CompressedPublisher.cfg
+++ b/compressed_image_transport/cfg/CompressedPublisher.cfg
@@ -7,7 +7,8 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 gen = ParameterGenerator()
 
 format_enum = gen.enum( [gen.const("jpeg", str_t, "jpeg", "JPEG lossy compression"),
-                         gen.const("png", str_t, "png", "PNG lossless compression")],
+                         gen.const("png", str_t, "png", "PNG lossless compression"),
+                         gen.const("qoi", str_t, "qoi", "QOI lossless compression")],
                         "Enum to set the compression format" )
 gen.add("format", str_t, 0, "Compression format", "jpeg", edit_method = format_enum)
 gen.add("jpeg_quality", int_t, 0, "JPEG quality percentile", 80, 1, 100)

--- a/compressed_image_transport/compressed_plugins.xml
+++ b/compressed_image_transport/compressed_plugins.xml
@@ -4,7 +4,7 @@
     type="compressed_image_transport::CompressedPublisher"
     base_class_type="image_transport::PublisherPlugin">
     <description>
-      This plugin publishes a CompressedImage using either JPEG or PNG compression.
+      This plugin publishes a CompressedImage using either JPEG, PNG or QOI compression.
     </description>
   </class>
 

--- a/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
@@ -66,7 +66,7 @@ protected:
                const PublishFn& publish_fn) const;
 
   struct Config {
-    // Compression format to use "jpeg", "png" or "tiff".
+    // Compression format to use "jpeg", "png", "tiff" or "qoi".
     std::string format;
 
     // PNG Compression Level from 0 to 9.  A higher value means a smaller size.

--- a/compressed_image_transport/include/compressed_image_transport/compression_common.h
+++ b/compressed_image_transport/include/compressed_image_transport/compression_common.h
@@ -45,6 +45,7 @@ enum compressionFormat
   JPEG = 0,
   PNG = 1,
   TIFF = 2,
+  QOI = 3,
 };
 
 } //namespace compressed_image_transport

--- a/compressed_image_transport/include/compressed_image_transport/qoi.hpp
+++ b/compressed_image_transport/include/compressed_image_transport/qoi.hpp
@@ -1,0 +1,66 @@
+/*
+From https://github.com/ShadowMitia/libqoi
+By Dimitri Belopopsky
+MIT License
+*/
+
+#ifndef QOI_HEADER
+#define QOI_HEADER
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <vector>
+
+namespace qoi {
+
+struct header {
+    // Image width in pixels
+    std::uint32_t width{};
+    // Image height in pixels
+    std::uint32_t height{};
+    // 3 = RGB, 4 = RGBA
+    std::uint8_t channels{};
+    // 0 = sRGB with linear alpha
+    // 1 = all channels linear
+    std::uint8_t colorspace{};
+};
+
+constexpr auto SRGB = 0x0;
+constexpr auto LINEAR = 0x1;
+
+constexpr unsigned char OP_RGB = 0b11111110;
+constexpr unsigned char OP_RGBA = 0b11111111;
+constexpr unsigned char OP_INDEX = 0b0;
+constexpr unsigned char OP_DIFF = 0b01000000;
+constexpr unsigned char OP_LUMA = 0b10000000;
+constexpr unsigned char OP_RUN = 0b11000000;
+
+constexpr std::array<unsigned char, 4> QOI_MAGIC{'q', 'o', 'i', 'f'};
+
+constexpr unsigned char END_MARKER_LENGTH = 8; // in bytes
+constexpr std::array<unsigned char, 8> padding{0, 0, 0, 0, 0, 0, 0, 1};
+constexpr unsigned char HEADER_SIZE = 14; // in bytes
+
+bool is_valid(std::vector<unsigned char> const& bytes) noexcept;
+
+header get_header(std::vector<unsigned char> const& image_to_decode);
+
+std::vector<unsigned char> decode(std::vector<unsigned char> const& image_to_decode);
+
+std::vector<unsigned char> encode(std::vector<unsigned char> const& orig_pixels, std::uint32_t width, std::uint32_t height, unsigned char channels);
+
+namespace utils {
+std::vector<unsigned char> read_binary(std::string const& path);
+void write_binary(const std::string& path, std::vector<unsigned char> const& bytes);
+} // namespace utils
+
+#ifdef QOI_HEADER_ONLY
+#include "qoi.cpp"
+#endif
+
+} // namespace qoi
+
+#endif

--- a/compressed_image_transport/package.xml
+++ b/compressed_image_transport/package.xml
@@ -11,6 +11,7 @@
   <url type="website">http://www.ros.org/wiki/image_transport_plugins</url>
   <author>Patrick Mihelich</author>
   <author>Julius Kammerl</author>
+  <author>Sammy Pfeiffer</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -40,6 +40,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include "compressed_image_transport/compression_common.h"
+#include "compressed_image_transport/qoi.hpp"
 
 #include <rclcpp/parameter_client.hpp>
 
@@ -117,64 +118,90 @@ void CompressedSubscriber::internalCallback(const CompressedImage::ConstSharedPt
 
   // Decode color/mono image
   try
-  {
-    cv_ptr->image = cv::imdecode(cv::Mat(message->data), config_.imdecode_flag);
+  {    
 
-    // Assign image encoding string
+    // Assign image encoding string and get compression format string
     const size_t split_pos = message->format.find(';');
-    if (split_pos==std::string::npos)
+    std::string image_encoding = message->format.substr(0, split_pos);
+    std::string compression_format = message->format.substr(split_pos+2, 3);
+
+    if (compression_format == "qoi")
     {
-      // Older version of compressed_image_transport does not signal image format
-      switch (cv_ptr->image.channels())
+      auto header = qoi::get_header(message->data);
+      auto img_pixels = qoi::decode(message->data);
+
+      // QOI can only do 3 or 4 channels (RGB/RGBA)
+      cv_ptr->encoding = enc::RGB8;
+      if (header.channels == 4)
+        cv_ptr->encoding = enc::RGBA8;
+      
+      // I need to make a copy or I get a black image
+      cv::Mat(header.height,
+              header.width,
+              cv_bridge::getCvType(cv_ptr->encoding),
+              &img_pixels[0]).copyTo(cv_ptr->image);
+
+      // QOI uses RGB, transform to BGR
+      if (header.channels == 3)
+        cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2BGR);
+      if (header.channels == 4)
+        cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGBA2BGRA);
+    }
+    else{
+      cv_ptr->image = cv::imdecode(cv::Mat(message->data), config_.imdecode_flag);
+
+      if (split_pos==std::string::npos)
       {
-        case 1:
-          cv_ptr->encoding = enc::MONO8;
-          break;
-        case 3:
-          cv_ptr->encoding = enc::BGR8;
-          break;
-        default:
-          RCLCPP_ERROR(logger_, "Unsupported number of channels: %i", cv_ptr->image.channels());
-          break;
-      }
-    } else
-    {
-      std::string image_encoding = message->format.substr(0, split_pos);
-
-      cv_ptr->encoding = image_encoding;
-
-      if ( enc::isColor(image_encoding))
-      {
-        std::string compressed_encoding = message->format.substr(split_pos);
-        bool compressed_bgr_image = (compressed_encoding.find("compressed bgr") != std::string::npos);
-
-        // Revert color transformation
-        if (compressed_bgr_image)
+        // Older version of compressed_image_transport does not signal image format
+        switch (cv_ptr->image.channels())
         {
-          // if necessary convert colors from bgr to rgb
-          if ((image_encoding == enc::RGB8) || (image_encoding == enc::RGB16))
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2RGB);
-
-          if ((image_encoding == enc::RGBA8) || (image_encoding == enc::RGBA16))
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2RGBA);
-
-          if ((image_encoding == enc::BGRA8) || (image_encoding == enc::BGRA16))
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2BGRA);
-        } else
-        {
-          // if necessary convert colors from rgb to bgr
-          if ((image_encoding == enc::BGR8) || (image_encoding == enc::BGR16))
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2BGR);
-
-          if ((image_encoding == enc::BGRA8) || (image_encoding == enc::BGRA16))
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2BGRA);
-
-          if ((image_encoding == enc::RGBA8) || (image_encoding == enc::RGBA16))
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2RGBA);
+          case 1:
+            cv_ptr->encoding = enc::MONO8;
+            break;
+          case 3:
+            cv_ptr->encoding = enc::BGR8;
+            break;
+          default:
+            RCLCPP_ERROR(logger_, "Unsupported number of channels: %i", cv_ptr->image.channels());
+            break;
         }
-      }
-      if (message->format.find("jpeg") != std::string::npos && enc::bitDepth(image_encoding) == 16) {
-        cv_ptr->image.convertTo(cv_ptr->image, CV_16U, 256);
+      } else
+      {
+        cv_ptr->encoding = image_encoding;
+
+        if ( enc::isColor(image_encoding))
+        {
+          std::string compressed_encoding = message->format.substr(split_pos);
+          bool compressed_bgr_image = (compressed_encoding.find("compressed bgr") != std::string::npos);
+
+          // Revert color transformation
+          if (compressed_bgr_image)
+          {
+            // if necessary convert colors from bgr to rgb
+            if ((image_encoding == enc::RGB8) || (image_encoding == enc::RGB16))
+              cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2RGB);
+
+            if ((image_encoding == enc::RGBA8) || (image_encoding == enc::RGBA16))
+              cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2RGBA);
+
+            if ((image_encoding == enc::BGRA8) || (image_encoding == enc::BGRA16))
+              cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2BGRA);
+          } else
+          {
+            // if necessary convert colors from rgb to bgr
+            if ((image_encoding == enc::BGR8) || (image_encoding == enc::BGR16))
+              cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2BGR);
+
+            if ((image_encoding == enc::BGRA8) || (image_encoding == enc::BGRA16))
+              cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2BGRA);
+
+            if ((image_encoding == enc::RGBA8) || (image_encoding == enc::RGBA16))
+              cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2RGBA);
+          }
+        }
+        if (message->format.find("jpeg") != std::string::npos && enc::bitDepth(image_encoding) == 16) {
+          cv_ptr->image.convertTo(cv_ptr->image, CV_16U, 256);
+        }
       }
     }
   }

--- a/compressed_image_transport/src/qoi.cpp
+++ b/compressed_image_transport/src/qoi.cpp
@@ -1,0 +1,267 @@
+/*
+From https://github.com/ShadowMitia/libqoi
+By Dimitri Belopopsky
+MIT License
+*/
+
+#include "compressed_image_transport/qoi.hpp"
+
+#include <iostream>
+
+namespace qoi {
+namespace utils {
+std::vector<unsigned char> read_binary(std::string const& path) {
+    std::ifstream file(path, std::fstream::ate | std::fstream::binary);
+    const auto size = file.tellg();
+    file.seekg(0);
+    std::vector<unsigned char> output;
+    output.resize(static_cast<std::size_t>(size));
+    if (not file.read(reinterpret_cast<char*>(output.data()), size)) { // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        std::cerr << "Couldn't read file : " << path << '\n';
+        return {};
+    }
+    return output;
+}
+
+void write_binary(const std::string& path, std::vector<unsigned char> const& bytes) {
+    std::ofstream file(path, std::ios::out | std::ios::binary);
+    const auto size = static_cast<std::streamsize>(bytes.size());
+    if (not file.write(reinterpret_cast<const char*>(bytes.data()), size)) { // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        std::cerr << "Couldn't write file : " << path << '\n';
+    }
+}
+
+} // namespace utils
+struct RGBA {
+    unsigned char r{0};
+    unsigned char g{0};
+    unsigned char b{0};
+    unsigned char a{0};
+
+    friend constexpr bool operator==(RGBA const& a, RGBA const& b) { return a.r == b.r and a.g == b.g and a.b == b.b and a.a == b.a; };
+};
+
+std::uint32_t read_4_be_bytes(std::vector<unsigned char> const& bytes, std::size_t position) {
+    const auto res = 0x0U // peekaboo
+                     | std::uint32_t(bytes[position + 0] << 24U) | std::uint32_t(bytes[position + 1] << 16U) | std::uint32_t(bytes[position + 2] << 8U) |
+                     std::uint32_t(bytes[position + 3] << 0U);
+    return res;
+};
+
+constexpr std::uint32_t pixel_hash(RGBA const& pix) noexcept { return (pix.r * 3 + pix.g * 5 + pix.b * 7 + pix.a * 11); };
+
+bool is_valid(const std::vector<unsigned char>& bytes) noexcept {
+    if (bytes.size() < qoi::HEADER_SIZE) {
+        return false;
+    }
+
+    if (bytes[0] != QOI_MAGIC[0] and bytes[1] != QOI_MAGIC[1] and bytes[2] != QOI_MAGIC[3]) {
+        return false;
+    }
+
+    return true;
+}
+
+header get_header(std::vector<unsigned char> const& image_to_decode) {
+    header image_header{};
+    image_header.width = read_4_be_bytes(image_to_decode, 4);
+    image_header.height = read_4_be_bytes(image_to_decode, 8);
+    image_header.channels = image_to_decode[12];
+    image_header.colorspace = image_to_decode[13];
+
+    // fmt::print("Header\n");
+    // fmt::print("Magic {:c}{:c}{:c}{:c}\n", image_to_decode[0], image_to_decode[1], image_to_decode[2], image_to_decode[3]);
+    // fmt::print("Width {}\n", image_header.width);
+    // fmt::print("Height {}\n", image_header.height);
+    // fmt::print("Channels {}\n", image_header.channels);
+    // fmt::print("Colorspace {}\n", image_header.colorspace);
+
+    return image_header;
+}
+
+std::vector<unsigned char> decode(std::vector<unsigned char> const& image_to_decode) {
+
+    const auto image_header = get_header(image_to_decode);
+    const auto size = static_cast<unsigned long>(image_header.width * image_header.height) * static_cast<unsigned long>(image_header.channels);
+
+    std::vector<unsigned char> pixels;
+    pixels.resize(size);
+
+    std::array<qoi::RGBA, 64> previous_pixels;
+    qoi::RGBA previous_pixel{0, 0, 0, 255};
+
+    std::size_t index = qoi::HEADER_SIZE;
+
+    for (std::size_t pixel_index = 0; pixel_index < size;) {
+        if (index < (image_to_decode.size() - qoi::END_MARKER_LENGTH)) {
+            const auto tag = image_to_decode[index++];
+
+            if (tag == qoi::OP_RGB) {
+                const auto r = image_to_decode[index++];
+                const auto g = image_to_decode[index++];
+                const auto b = image_to_decode[index++];
+                previous_pixel = qoi::RGBA{r, g, b, previous_pixel.a};
+            } else if (tag == qoi::OP_RGBA) {
+                const auto r = image_to_decode[index++];
+                const auto g = image_to_decode[index++];
+                const auto b = image_to_decode[index++];
+                const auto a = image_to_decode[index++];
+                previous_pixel = qoi::RGBA{r, g, b, a};
+            } else {
+                constexpr unsigned char MASK = 0b11000000U;
+
+                if ((tag & MASK) == qoi::OP_INDEX) {
+                    const auto previous_index = (tag & 0b00111111U);
+                    previous_pixel = previous_pixels[previous_index];
+                } else if ((tag & MASK) == qoi::OP_DIFF) {
+                    previous_pixel.r += static_cast<unsigned char>((((tag & 0b110000U) >> 4U) & 0b11U) - 2);
+                    previous_pixel.g += static_cast<unsigned char>((((tag & 0b001100U) >> 2U) & 0b11U) - 2);
+                    previous_pixel.b += static_cast<unsigned char>((((tag & 0b000011U) >> 0U) & 0b11U) - 2);
+                } else if ((tag & MASK) == qoi::OP_LUMA) {
+                    const auto data = image_to_decode[index++];
+                    const auto vg = static_cast<unsigned char>((tag & 0x3FU) - 32);
+                    previous_pixel.r += (vg - 8 + static_cast<unsigned char>((data >> 4U) & 0xFU));
+                    previous_pixel.g += vg;
+                    previous_pixel.b += (vg - 8 + static_cast<unsigned char>((data >> 0U) & 0xFU));
+                } else if ((tag & MASK) == qoi::OP_RUN) {
+                    const auto run = tag & 0b00111111U;
+                    for (std::size_t j = 0; j < run; j++) {
+                        if (image_header.channels == 4) {
+                            pixels[pixel_index++] = previous_pixel.r;
+                            pixels[pixel_index++] = previous_pixel.g;
+                            pixels[pixel_index++] = previous_pixel.b;
+                            pixels[pixel_index++] = previous_pixel.a;
+                        } else {
+                            pixels[pixel_index++] = previous_pixel.r;
+                            pixels[pixel_index++] = previous_pixel.g;
+                            pixels[pixel_index++] = previous_pixel.b;
+                        }
+                    }
+                }
+            }
+            const auto pixel_hash_index = (pixel_hash(previous_pixel) % 64);
+            previous_pixels[static_cast<std::size_t>(pixel_hash_index)] = previous_pixel;
+        }
+
+        if (image_header.channels == 4) {
+            pixels[pixel_index++] = previous_pixel.r;
+            pixels[pixel_index++] = previous_pixel.g;
+            pixels[pixel_index++] = previous_pixel.b;
+            pixels[pixel_index++] = previous_pixel.a;
+        } else {
+            pixels[pixel_index++] = previous_pixel.r;
+            pixels[pixel_index++] = previous_pixel.g;
+            pixels[pixel_index++] = previous_pixel.b;
+        }
+    }
+
+    return pixels;
+}
+
+std::vector<unsigned char> encode(std::vector<unsigned char> const& orig_pixels, std::uint32_t width, std::uint32_t height, unsigned char channels) {
+
+    // TODO: extract as argument
+    qoi::header head{};
+    head.width = width;
+    head.height = height;
+    head.channels = channels;
+    head.colorspace = qoi::SRGB;
+
+    const auto size = head.width * head.height * head.channels;
+    const auto qoi_size = head.width * head.height * (head.channels + 1) + qoi::HEADER_SIZE + qoi::END_MARKER_LENGTH;
+    std::vector<unsigned char> encoded_pixels;
+    encoded_pixels.resize(qoi_size, 0x0);
+
+    std::array<qoi::RGBA, 64> previous_pixels;
+    qoi::RGBA previous_pixel{0, 0, 0, 255};
+    qoi::RGBA pixel{0, 0, 0, 255};
+
+    encoded_pixels[0] = qoi::QOI_MAGIC[0];
+    encoded_pixels[1] = qoi::QOI_MAGIC[1];
+    encoded_pixels[2] = qoi::QOI_MAGIC[2];
+    encoded_pixels[3] = qoi::QOI_MAGIC[3];
+    encoded_pixels[4] = static_cast<unsigned char>((head.width & 0xFF000000U) >> 24U);
+    encoded_pixels[5] = static_cast<unsigned char>((head.width & 0x00FF0000U) >> 16U);
+    encoded_pixels[6] = static_cast<unsigned char>((head.width & 0x0000FF00U) >> 8U);
+    encoded_pixels[7] = static_cast<unsigned char>((head.width & 0x000000FFU) >> 0U);
+    encoded_pixels[8] = static_cast<unsigned char>((head.height & 0xFF000000U) >> 24U);
+    encoded_pixels[9] = static_cast<unsigned char>((head.height & 0x00FF0000U) >> 16U);
+    encoded_pixels[10] = static_cast<unsigned char>((head.height & 0x0000FF00U) >> 8U);
+    encoded_pixels[11] = static_cast<unsigned char>((head.height & 0x000000FFU) >> 0U);
+    encoded_pixels[12] = head.channels;
+    encoded_pixels[13] = head.colorspace;
+
+    std::size_t index = qoi::HEADER_SIZE;
+
+    auto run = 0U;
+
+    for (std::size_t pixel_index = 0; pixel_index < size; pixel_index += head.channels) {
+        if (head.channels == 4) {
+            pixel = qoi::RGBA{orig_pixels[pixel_index + 0], orig_pixels[pixel_index + 1], orig_pixels[pixel_index + 2], orig_pixels[pixel_index + 3]};
+        } else {
+            pixel.r = orig_pixels[pixel_index + 0];
+            pixel.g = orig_pixels[pixel_index + 1];
+            pixel.b = orig_pixels[pixel_index + 2];
+        }
+        if (previous_pixel == pixel) {
+            run++;
+            if (run == 62 || pixel_index == (size - head.channels)) {
+                encoded_pixels[index++] = static_cast<unsigned char>(qoi::OP_RUN | (run - 1));
+                run = 0;
+            }
+
+        } else {
+
+            if (run > 0) {
+                encoded_pixels[index++] = static_cast<unsigned char>(qoi::OP_RUN | (run - 1));
+                run = 0;
+            }
+
+            const auto index_pos = static_cast<unsigned char>(qoi::pixel_hash(pixel) % 64);
+
+            if (previous_pixels[index_pos] == pixel) {
+                encoded_pixels[index++] = qoi::OP_INDEX | index_pos;
+            } else {
+                previous_pixels[index_pos] = pixel;
+
+                if (pixel.a == previous_pixel.a) {
+                    const auto vr = static_cast<signed char>(pixel.r - previous_pixel.r);
+                    const auto vg = static_cast<signed char>(pixel.g - previous_pixel.g);
+                    const auto vb = static_cast<signed char>(pixel.b - previous_pixel.b);
+
+                    const auto vg_r = vr - vg;
+                    const auto vg_b = vb - vg;
+
+                    if (vr > -3 and vr < 2 and vg > -3 and vg < 2 and vb > -3 and vb < 2) {
+                        encoded_pixels[index++] = static_cast<unsigned char>(qoi::OP_DIFF | (vr + 2) << 4U | (vg + 2) << 2U | (vb + 2));
+                    } else if (vg_r > -9 and vg_r < 8 and vg > -33 and vg < 32 and vg_b > -9 and vg_b < 8) {
+                        encoded_pixels[index++] = static_cast<unsigned char>(qoi::OP_LUMA | static_cast<unsigned char>(vg + 32));
+                        encoded_pixels[index++] = static_cast<unsigned char>(static_cast<unsigned char>(vg_r + 8) << 4U | static_cast<unsigned char>(vg_b + 8));
+                    } else {
+                        encoded_pixels[index++] = qoi::OP_RGB;
+                        encoded_pixels[index++] = pixel.r;
+                        encoded_pixels[index++] = pixel.g;
+                        encoded_pixels[index++] = pixel.b;
+                    }
+                } else {
+                    encoded_pixels[index++] = qoi::OP_RGBA;
+                    encoded_pixels[index++] = pixel.r;
+                    encoded_pixels[index++] = pixel.g;
+                    encoded_pixels[index++] = pixel.b;
+                    encoded_pixels[index++] = pixel.a;
+                }
+            }
+        }
+        previous_pixel = pixel;
+    }
+
+    for (auto const& pad : padding) {
+        encoded_pixels[index++] = pad;
+    }
+    encoded_pixels.resize(index);
+    encoded_pixels.shrink_to_fit();
+
+    return encoded_pixels;
+}
+
+} // namespace qoi


### PR DESCRIPTION
This is a sibling PR of: https://github.com/ros-perception/image_transport_plugins/pull/103
However, note that I developed and tested these changes in ROS1. Given the similarity of the codebase I hope it just works by adding the same changes here.

 The Quite OK Image format (https://qoiformat.org/) is a good substitute of PNG for lossless compression.

As per QOI's website:
> QOI is fast. It losslessy compresses images to a similar size of PNG, while offering 20x-50x faster encoding and 3x-4x faster decoding

This commit adds it as a compressed image transport thanks to Dimitri Belopopsky's (@ShadowMitia) MIT Licensed
library (https://github.com/ShadowMitia/libqoi) implementing Dominic Szablewski's QOI algorithm (which is
CC0 licensed, public domain).

To give context, I implemented this to practice C++ and to provide an alternative to PNG compression for when we'd like lossless compression or to have an alpha channel without framerate drop. Currently using PNG drops a 640x480 webcam stream 30fps to 3fps. With QOI it stays at 30fps.
Taking as baseline raw image publishing with video_stream_opencv, and subscribing with rqt_image_view, on my i7-10875H CPU @ 2.30GHz × 16, QOI compression adds 28% CPU usage and QOI decompression adds 13% CPU usage. Feels reasonable to me, specially compared to PNG going over 100% CPU usage and dropping most of the frames.

I would gladly appreciate help on how to eliminate the (what I think is) unnecessary copy of the image in the publisher and the subscriber.
