### PR TITLE
Fix uninitialized memory usage in compressedDepth transport

### DIFF
--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -224,7 +224,7 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
   int numChannels = enc::numChannels(message.encoding);
 
   // Image compression configuration
-  ConfigHeader compressionConfig;
+  ConfigHeader compressionConfig {};
   compressionConfig.format = INV_DEPTH;
 
   // Compressed image data


### PR DESCRIPTION
The `ConfigHeader` struct in compressedDepth encoder was not initialized (or at least zero-initialized by the compiler). So `compressionConfig.depthParam` array contains uninitialized memory. For 32-bit images, that's fine because these values are overwritten later. However, for 16UC1, there are no writes to these variables, meaning the uninitilized memory content leaks to the output compressed messages! So this might even be a security issue (although I have no POC).

This simple change will zero-initialize the struct so that the variables are zero by default.

I don't think there could be any bad consequences for any downstream code. The values are "random" now, so nobody could rely on their contents in the 16UC1 case. And 32FC1 behavior remains untouched.

Here's an illustrative memory view of a message I've just loaded from a bag file I had: in the upper part, you can see the `ConfigHeader` extracted from the data, and in the lower part, you can see the bytes. Normally, all bytes preceding `\211PNG` should be zero. With this PR, they are.

![image](https://user-images.githubusercontent.com/182533/210668511-3f682714-406a-4b01-976b-f9a18073a014.png)
