### PR TITLE
Revert "add params for jpeg compression"

### DIFF
--- a/compressed_image_transport/cfg/CompressedPublisher.cfg
+++ b/compressed_image_transport/cfg/CompressedPublisher.cfg
@@ -11,9 +11,6 @@ format_enum = gen.enum( [gen.const("jpeg", str_t, "jpeg", "JPEG lossy compressio
                         "Enum to set the compression format" )
 gen.add("format", str_t, 0, "Compression format", "jpeg", edit_method = format_enum)
 gen.add("jpeg_quality", int_t, 0, "JPEG quality percentile", 80, 1, 100)
-gen.add("jpeg_progressive", bool_t, 0, "Enable compression to progressive JPEG", False)
-gen.add("jpeg_optimize", bool_t, 0, "Enable JPEG compress optimization", False)
-gen.add("jpeg_restart_interval", int_t, 0, "JPEG restart interval", 0, 0, 65535)
 gen.add("png_level", int_t, 0, "PNG compression level", 9, 1, 9)
 
 exit(gen.generate(PACKAGE, "CompressedPublisher", "CompressedPublisher"))

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -36,7 +36,6 @@
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.h>
 #include <opencv2/highgui/highgui.hpp>
-#include <opencv2/imgcodecs.hpp>
 #include <boost/make_shared.hpp>
 
 #include "compressed_image_transport/compression_common.h"
@@ -85,6 +84,7 @@ void CompressedPublisher::publish(const sensor_msgs::Image& message, const Publi
 
   // Compression settings
   std::vector<int> params;
+  params.resize(3, 0);
 
   // Get codec configuration
   compressionFormat encodingFormat = UNDEFINED;
@@ -102,15 +102,8 @@ void CompressedPublisher::publish(const sensor_msgs::Image& message, const Publi
     // JPEG Compression
     case JPEG:
     {
-      params.resize(9, 0);
-      params[0] = IMWRITE_JPEG_QUALITY;
+      params[0] = CV_IMWRITE_JPEG_QUALITY;
       params[1] = config_.jpeg_quality;
-      params[2] = IMWRITE_JPEG_PROGRESSIVE;
-      params[3] = config_.jpeg_progressive ? 1 : 0;
-      params[4] = IMWRITE_JPEG_OPTIMIZE;
-      params[5] = config_.jpeg_optimize ? 1 : 0;
-      params[6] = IMWRITE_JPEG_RST_INTERVAL;
-      params[7] = config_.jpeg_restart_interval;
 
       // Update ros message format header
       compressed.format += "; jpeg compressed ";
@@ -166,8 +159,7 @@ void CompressedPublisher::publish(const sensor_msgs::Image& message, const Publi
       // PNG Compression
     case PNG:
     {
-      params.resize(3, 0);
-      params[0] = IMWRITE_PNG_COMPRESSION;
+      params[0] = CV_IMWRITE_PNG_COMPRESSION;
       params[1] = config_.png_level;
 
       // Update ros message format header


### PR DESCRIPTION
As brought up in https://github.com/ros-perception/image_transport_plugins/pull/123#issuecomment-1373555774, this PR reverts https://github.com/ros-perception/image_transport_plugins/pull/35 in melodic-devel so we can make a release without breaking ABI.