### PR TITLE
Fix passing parameters to cv::imencode() for OpenCV 4.7

### DIFF
--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -217,7 +217,6 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
 
   // Compression settings
   std::vector<int> params;
-  params.resize(3, 0);
 
   // Bit depth of image encoding
   int bitDepth = enc::bitDepth(message.encoding);
@@ -234,8 +233,9 @@ sensor_msgs::CompressedImage::Ptr encodeCompressedDepthImage(
   compressed->format += "; compressedDepth " + compression_format;
 
   // Check input format
-  params[0] = cv::IMWRITE_PNG_COMPRESSION;
-  params[1] = png_level;
+  params.reserve(2);
+  params.emplace_back(cv::IMWRITE_PNG_COMPRESSION);
+  params.emplace_back(png_level);
 
   if ((bitDepth == 32) && (numChannels == 1))
   {

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -102,15 +102,15 @@ void CompressedPublisher::publish(const sensor_msgs::Image& message, const Publi
     // JPEG Compression
     case JPEG:
     {
-      params.resize(9, 0);
-      params[0] = IMWRITE_JPEG_QUALITY;
-      params[1] = config_.jpeg_quality;
-      params[2] = IMWRITE_JPEG_PROGRESSIVE;
-      params[3] = config_.jpeg_progressive ? 1 : 0;
-      params[4] = IMWRITE_JPEG_OPTIMIZE;
-      params[5] = config_.jpeg_optimize ? 1 : 0;
-      params[6] = IMWRITE_JPEG_RST_INTERVAL;
-      params[7] = config_.jpeg_restart_interval;
+      params.reserve(8);
+      params.emplace_back(IMWRITE_JPEG_QUALITY);
+      params.emplace_back(config_.jpeg_quality);
+      params.emplace_back(IMWRITE_JPEG_PROGRESSIVE);
+      params.emplace_back(config_.jpeg_progressive ? 1 : 0);
+      params.emplace_back(IMWRITE_JPEG_OPTIMIZE);
+      params.emplace_back(config_.jpeg_optimize ? 1 : 0);
+      params.emplace_back(IMWRITE_JPEG_RST_INTERVAL);
+      params.emplace_back(config_.jpeg_restart_interval);
 
       // Update ros message format header
       compressed.format += "; jpeg compressed ";
@@ -166,9 +166,9 @@ void CompressedPublisher::publish(const sensor_msgs::Image& message, const Publi
       // PNG Compression
     case PNG:
     {
-      params.resize(3, 0);
-      params[0] = IMWRITE_PNG_COMPRESSION;
-      params[1] = config_.png_level;
+      params.reserve(2);
+      params.emplace_back(IMWRITE_PNG_COMPRESSION);
+      params.emplace_back(config_.png_level);
 
       // Update ros message format header
       compressed.format += "; png compressed ";


### PR DESCRIPTION
The number of elements in vector params needs to be even ([cv::imencode()](https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#ga461f9ac09887e47797a54567df3b8b63), [cv::imwrite()](https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#gabbc7ef1aa2edfaa87772f1202d67e0ce)).

OpenCV version 4.7 complains if the vector has an odd number of elements, like 3 or 9:
https://github.com/opencv/opencv/commit/f0df78b7e743a8d735a4bc669ae64a155f08645d#diff-c43d1948c31949b9c25dea5c7f019e1bfed04d98ee9fb1a97f7b1b98dd9b5525R718

The `reserve()` + `emplace_back()` approach has been adapted from the `rolling` branch, where the bug has already been fixed in the same way in https://github.com/ros-perception/image_transport_plugins/commit/7ca907277eda51ec2fbb71409bda33d1395d6127.