### PR TITLE
Initialize is_bigendian when decoding using libjpeg turbo

### DIFF
--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -32,6 +32,7 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
+#include <boost/endian/arithmetic.hpp>
 #include "compressed_image_transport/compressed_subscriber.h"
 #include <sensor_msgs/image_encodings.h>
 #include <cv_bridge/cv_bridge.h>
@@ -111,6 +112,8 @@ sensor_msgs::ImagePtr CompressedSubscriber::decompressJPEG(const std::vector<uin
   ret->width = width;
   ret->height = height;
   ret->encoding = source_encoding;
+  // consistent with cv_bridge
+  ret->is_bigendian = (boost::endian::order::native == boost::endian::order::big);  // NOLINT
 
   int pixelFormat;
 


### PR DESCRIPTION
When an image is decoded via libjpeg turbo, the result might differ from the cv_bridge result in the `is_bigendian` field of the decoded image. This PR fixes it.

However, the problem is actually negligible as no major platforms running ROS are big-endian (maybe old Macs?).