### PR TITLE
Added basic input checking for RVL

### DIFF
--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -131,7 +131,7 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
         memcpy(&rows, &buffer[4], 4);
         // Sanity check - the best compression ratio is 4x; we leave some buffer, so we check whether the output image would
         // not be more than 10x larger than the compressed one. If it is, we probably received corrupted data.
-        if ((cols * rows) * 2 * 10 > imageData.size())
+        if ((cols * rows) * 2 > imageData.size() * 10)
         {
           ROS_ERROR_THROTTLE(1.0, "Received malformed RVL-encoded image. It pretends to have size %ux%u.", cols, rows);
           return sensor_msgs::Image::Ptr();

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -126,16 +126,27 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
         }
       } else if (compression_format == "rvl") {
         const unsigned char *buffer = imageData.data();
+
         uint32_t cols, rows;
         memcpy(&cols, &buffer[0], 4);
         memcpy(&rows, &buffer[4], 4);
-        // Sanity check - the best compression ratio is 4x; we leave some buffer, so we check whether the output image would
-        // not be more than 10x larger than the compressed one. If it is, we probably received corrupted data.
-        if ((cols * rows) * 2 > imageData.size() * 10)
+        if (rows == 0 || cols == 0)
         {
-          ROS_ERROR_THROTTLE(1.0, "Received malformed RVL-encoded image. It pretends to have size %ux%u.", cols, rows);
+          ROS_ERROR_THROTTLE(1.0, "Received malformed RVL-encoded image. Size %ix%i contains zero.", cols, rows);
           return sensor_msgs::Image::Ptr();
         }
+
+        // Sanity check - the best compression ratio is 4x; we leave some buffer, so we check whether the output image would
+        // not be more than 10x larger than the compressed one. If it is, we probably received corrupted data.
+        // The condition should be "numPixels * 2 > compressed.size() * 10" (because each pixel is 2 bytes), but to prevent
+        // overflow, we have canceled out the *2 from both sides of the inequality.
+        const auto numPixels = static_cast<uint64_t>(rows) * cols;
+        if (numPixels > std::numeric_limits<int>::max() || numPixels > static_cast<uint64_t>(compressed.size()) * 5)
+        {
+          ROS_ERROR_THROTTLE(1.0, "Received malformed RVL-encoded image. It reports size %ux%u.", cols, rows);
+          return sensor_msgs::Image::Ptr();
+        }
+
         decompressed = Mat(rows, cols, CV_16UC1);
         RvlCodec rvl;
         rvl.DecompressRVL(&buffer[8], decompressed.ptr<unsigned short>(), cols * rows);

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -141,7 +141,7 @@ sensor_msgs::Image::Ptr decodeCompressedDepthImage(const sensor_msgs::Compressed
         // The condition should be "numPixels * 2 > compressed.size() * 10" (because each pixel is 2 bytes), but to prevent
         // overflow, we have canceled out the *2 from both sides of the inequality.
         const auto numPixels = static_cast<uint64_t>(rows) * cols;
-        if (numPixels > std::numeric_limits<int>::max() || numPixels > static_cast<uint64_t>(compressed.size()) * 5)
+        if (numPixels > std::numeric_limits<int>::max() || numPixels > static_cast<uint64_t>(imageData.size()) * 5)
         {
           ROS_ERROR_THROTTLE(1.0, "Received malformed RVL-encoded image. It reports size %ux%u.", cols, rows);
           return sensor_msgs::Image::Ptr();


### PR DESCRIPTION
RVL blindly reads the first 8 bytes of the image and interprets them as image dimensions. I've just added a simple sanity check that can prevent *some* segfaults in case malformed data are passed.