### PR TITLE
[foxy-devel] transport scoped parameters

### DIFF
--- a/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
@@ -92,52 +92,12 @@ private:
 
   void declareParameters(rclcpp::Node* node, const std::string& base_topic);
 
-  template<typename T>
-  void declareParameter(rclcpp::Node* node,
-                        const std::string &base_name,
-                        const std::string &transport_name,
-                        const T &default_value,
-                        T &out_parameter,
-                        const rcl_interfaces::msg::ParameterDescriptor &descriptor);
+  rclcpp::ParameterValue declareParameter(rclcpp::Node* node,
+                                          const std::string &base_name,
+                                          const std::string &transport_name,
+                                          const rclcpp::ParameterValue &default_value,
+                                          const rcl_interfaces::msg::ParameterDescriptor &descriptor);
 
 };
-
-template<typename T>
-void CompressedPublisher::declareParameter(rclcpp::Node* node,
-                                           const std::string& base_name,
-                                           const std::string &transport_name,
-                                           const T &default_value,
-                                           T &out_parameter,
-                                           const rcl_interfaces::msg::ParameterDescriptor &descriptor)
-{
-  //transport scoped parameter (e.g. image_raw.compressed.format)
-  const std::string param_name = base_name + "." + transport_name + "." + descriptor.name;
-
-  try {
-    out_parameter = node->declare_parameter(param_name, default_value, descriptor);
-  } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
-    RCLCPP_DEBUG(logger_, "%s was previously declared", descriptor.name.c_str());
-    out_parameter = node->get_parameter(param_name).get_value<T>();
-  }
-
-  T value_set = out_parameter;
-
-  //deprecated non-scoped parameter name (e.g. image_raw.format)
-  const std::string deprecated_name = base_name + "." + descriptor.name;
-  deprecatedParameters_.push_back(deprecated_name);
-
-  // transport scoped parameter as default, otherwise we would overwrite
-  try {
-    out_parameter = node->declare_parameter(deprecated_name, out_parameter, descriptor);
-  } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
-    RCLCPP_DEBUG(logger_, "%s was previously declared", descriptor.name.c_str());
-    out_parameter = node->get_parameter(deprecated_name).get_value<T>();
-  }
-
-  // in case parameter was set through deprecated keep transport scoped parameter in sync
-  if(value_set != out_parameter)
-    node->set_parameter(rclcpp::Parameter(param_name, out_parameter));
-
-}
 
 } //namespace compressed_image_transport


### PR DESCRIPTION
# Aim

- fix #140
- support new transport scoped parameters and current behavior (to be deprecated)

# Reason

- following ROS1 image_transport documentation in ROS2 way
- avoiding clash between parameters from image_transport plugins

Details in #140

# Scope

- only `CompressedPublisher`

If agreed on implementation I may rework the rest within this pull.

# Short Description

- `<image>.<transport>.<param>` as future replacement of  `<image>.<param>`
- support both ways for now
- emit deprecation warnings on setting through non-transport scoped parameter

# Example

```bash
ros2 launch realsense2_camera rs_launch.py

# ...
realsense2_camera_node-1] [WARN] [1680595074.360039582] [CompressedPublisher]: parameter `.depth.image_rect_raw.format` is deprecated; use transport qualified name `.depth.image_rect_raw.compressed.format`
[realsense2_camera_node-1] [WARN] [1680595074.360153760] [CompressedPublisher]: parameter `.depth.image_rect_raw.png_level` is deprecated; use transport qualified name `.depth.image_rect_raw.compressed.png_level`
[realsense2_camera_node-1] [WARN] [1680595074.360203519] [CompressedPublisher]: parameter `.depth.image_rect_raw.jpeg_quality` is deprecated; use transport qualified name `.depth.image_rect_raw.compressed.jpeg_quality`
# ...
[realsense2_camera_node-1] [WARN] [1680595074.412855043] [CompressedPublisher]: parameter `.color.image_raw.format` is deprecated; use transport qualified name `.color.image_raw.compressed.format`
[realsense2_camera_node-1] [WARN] [1680595074.412951851] [CompressedPublisher]: parameter `.color.image_raw.png_level` is deprecated; use transport qualified name `.color.image_raw.compressed.png_level`
[realsense2_camera_node-1] [WARN] [1680595074.413044543] [CompressedPublisher]: parameter `.color.image_raw.jpeg_quality` is deprecated; use transport qualified name `.color.image_raw.compressed.jpeg_quality`

```

```bash
ros2 param list
/camera/camera:
  .color.image_raw.compressed.format
  .color.image_raw.compressed.jpeg_quality
  .color.image_raw.compressed.png_level
  .color.image_raw.format
  .color.image_raw.jpeg_quality
  .color.image_raw.png_level
  .depth.image_rect_raw.compressed.format
  .depth.image_rect_raw.compressed.jpeg_quality
  .depth.image_rect_raw.compressed.png_level
  .depth.image_rect_raw.format
  .depth.image_rect_raw.jpeg_quality
  .depth.image_rect_raw.png_level
# ...
```

# Implementation

- parameter event handler emitting deprecation warnings on setting non-scoped parameters
- declare and sync value
  - transport scoped parameter
  - non-scoped parameter