### PR TITLE
[rolling] reconfigurable transport scoped parameters for CompressedSubscriber

### DIFF
--- a/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_publisher.h
@@ -33,6 +33,7 @@
 *********************************************************************/
 
 #include <string>
+#include <vector>
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
@@ -78,11 +79,7 @@ private:
 
   rclcpp::Subscription<ParameterEvent>::SharedPtr parameter_subscription_;
 
-  void declareParameters(rclcpp::Node* node, const std::string& base_topic);
-
-  void declareParameter(rclcpp::Node* node,
-                        const std::string &base_name,
-                        const std::string &transport_name,
+  void declareParameter(const std::string &base_name,
                         const ParameterDefinition &definition);
 
   void onParameterEvent(ParameterEvent::SharedPtr event, std::string full_name, std::string base_name);

--- a/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_subscriber.h
@@ -33,6 +33,7 @@
 *********************************************************************/
 
 #include <string>
+#include <vector>
 
 #include <rclcpp/node.hpp>
 #include <rclcpp/subscription_options.hpp>
@@ -41,7 +42,11 @@
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <image_transport/simple_subscriber_plugin.hpp>
 
+#include "compressed_image_transport/compression_common.h"
+
 namespace compressed_image_transport {
+
+using ParameterEvent = rcl_interfaces::msg::ParameterEvent;
 
 class CompressedSubscriber final : public image_transport::SimpleSubscriberPlugin<sensor_msgs::msg::CompressedImage>
 {
@@ -66,12 +71,21 @@ protected:
   void internalCallback(const sensor_msgs::msg::CompressedImage::ConstSharedPtr& message,
                         const Callback& user_cb) override;
 
-  struct Config {
-    int imdecode_flag;
-  };
-
-  Config config_;
   rclcpp::Logger logger_;
+  rclcpp::Node * node_;
+
+private:
+  std::vector<std::string> parameters_;
+  std::vector<std::string> deprecatedParameters_;
+
+  rclcpp::Subscription<ParameterEvent>::SharedPtr parameter_subscription_;
+
+  int imdecodeFlagFromConfig();
+
+  void declareParameter(const std::string &base_name,
+                        const ParameterDefinition &definition);
+
+  void onParameterEvent(ParameterEvent::SharedPtr event, std::string full_name, std::string base_name);
 };
 
 } //namespace image_transport

--- a/compressed_image_transport/include/compressed_image_transport/compression_common.h
+++ b/compressed_image_transport/include/compressed_image_transport/compression_common.h
@@ -35,6 +35,9 @@
 #ifndef COMPRESSED_IMAGE_TRANSPORT_COMPRESSION_COMMON
 #define COMPRESSED_IMAGE_TRANSPORT_COMPRESSION_COMMON
 
+#include <rclcpp/parameter_value.hpp>
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+
 namespace compressed_image_transport
 {
 
@@ -47,19 +50,6 @@ enum compressionFormat
   TIFF = 2,
 };
 
-// Parameters
-// Note - what is below would be moved to separate file, e.g. `compressed_publisher_cfg.h`
-
-enum compressedParameters
-{
-  FORMAT = 0,
-  PNG_LEVEL,
-  JPEG_QUALITY,
-  TIFF_RESOLUTION_UNIT,
-  TIFF_XDPI,
-  TIFF_YDPI
-};
-
 using ParameterDescriptor = rcl_interfaces::msg::ParameterDescriptor;
 using ParameterValue = rclcpp::ParameterValue;
 
@@ -67,70 +57,6 @@ struct ParameterDefinition
 {
   const ParameterValue defaultValue;
   const ParameterDescriptor descriptor;
-};
-
-const struct ParameterDefinition kParameters[] =
-{
-  { //FORMAT - Compression format to use "jpeg", "png" or "tiff".
-    ParameterValue("jpeg"),
-    ParameterDescriptor()
-      .set__name("format")
-      .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_STRING)
-      .set__description("Compression method")
-      .set__read_only(false)
-      .set__additional_constraints("Supported values: [jpeg, png, tiff]")
-  },
-  { //PNG_LEVEL - PNG Compression Level from 0 to 9.  A higher value means a smaller size.
-    ParameterValue((int)3), //Default to OpenCV default of 3
-    ParameterDescriptor()
-      .set__name("png_level")
-      .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER)
-      .set__description("Compression level for PNG format")
-      .set__read_only(false)
-      .set__integer_range(
-        {rcl_interfaces::msg::IntegerRange()
-          .set__from_value(0)
-          .set__to_value(9)
-          .set__step(1)})
-  },
-  { //JPEG_QUALITY - JPEG Quality from 0 to 100 (higher is better quality).
-    ParameterValue((int)95), //Default to OpenCV default of 95.
-    ParameterDescriptor()
-      .set__name("jpeg_quality")
-      .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER)
-      .set__description("Image quality for JPEG format")
-      .set__read_only(false)
-      .set__integer_range(
-        {rcl_interfaces::msg::IntegerRange()
-          .set__from_value(1)
-          .set__to_value(100)
-          .set__step(1)})
-  },
-  { //TIFF_RESOLUTION_UNIT - TIFF resolution unit, can be one of "none", "inch", "centimeter".
-    ParameterValue("inch"),
-    ParameterDescriptor()
-      .set__name("tiff.res_unit")
-      .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_STRING)
-      .set__description("tiff resolution unit")
-      .set__read_only(false)
-      .set__additional_constraints("Supported values: [none, inch, centimeter]")
-  },
-  { //TIFF_XDPI
-    ParameterValue((int)-1),
-    ParameterDescriptor()
-      .set__name("tiff.xdpi")
-      .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER)
-      .set__description("tiff xdpi")
-      .set__read_only(false)
-  },
-  { //TIFF_YDPI
-    ParameterValue((int)-1),
-    ParameterDescriptor()
-      .set__name("tiff.ydpi")
-      .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER)
-      .set__description("tiff ydpi")
-      .set__read_only(false)
-  }
 };
 
 } //namespace compressed_image_transport


### PR DESCRIPTION
CompressedSubscriber
- #140 like
- #108 like 

#108 is simply reading mode before image decoding

Some CompressedPublisher cleanup to have common structure

In the screenshot:
- camera driver (publisher)
- rqt_image_view (subscriber)
  - in CLI deprecation warnings visible
- rqt_reconfigure (parameters)
  - dynamically changing through deprecated and new parameter

![image](https://user-images.githubusercontent.com/9095769/232757623-f6258e92-6cec-47e8-85d5-87e92f9020d8.png)

## Design Decisions

Constant parameter table thrown back to `compressed_publisher.cpp` and `compressed_subscriber.cpp`
- having those in separate files would be overkill - e.g. subscriber has 1 parameter

I decided not to overthink this too much.

After deprecated parameters are removed in the future the only thing left will be constant table with definitions.





