### PR TITLE
[ROS2] reconfigurable transport scoped parameters for theora

### DIFF
--- a/theora_image_transport/include/theora_image_transport/compression_common.h
+++ b/theora_image_transport/include/theora_image_transport/compression_common.h
@@ -1,0 +1,55 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2012, Willow Garage, Inc.
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef THEORA_IMAGE_TRANSPORT_COMPRESSION_COMMON
+#define THEORA_IMAGE_TRANSPORT_COMPRESSION_COMMON
+
+#include <rclcpp/parameter_value.hpp>
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+
+namespace theora_image_transport
+{
+
+using ParameterDescriptor = rcl_interfaces::msg::ParameterDescriptor;
+using ParameterValue = rclcpp::ParameterValue;
+
+struct ParameterDefinition
+{
+  const ParameterValue defaultValue;
+  const ParameterDescriptor descriptor;
+};
+
+} //namespace theora_image_transport
+
+#endif

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -406,12 +406,12 @@ void TheoraPublisher::updateKeyframeFrequency() const
 void TheoraPublisher::declareParameter(const std::string &base_name,
                                        const ParameterDefinition &definition)
 {
-  //transport scoped parameter (e.g. image_raw.compressed.format)
+  //transport scoped parameter (e.g. image_raw.theora.quality)
   const std::string transport_name = getTransportName();
   const std::string param_name = base_name + "." + transport_name + "." + definition.descriptor.name;
   parameters_.push_back(param_name);
 
-  //deprecated non-scoped parameter name (e.g. image_raw.format)
+  //deprecated non-scoped parameter name (e.g. image_raw.quality)
   const std::string deprecated_name = base_name + "." + definition.descriptor.name;
   deprecatedParameters_.push_back(deprecated_name);
 
@@ -453,7 +453,7 @@ void TheoraPublisher::onParameterEvent(ParameterEvent::SharedPtr event, std::str
 
     size_t baseNameIndex = name.find(base_name); //name was generated from base_name, has to succeed
     size_t paramNameIndex = baseNameIndex + base_name.size();
-    //e.g. `color.image_raw.` + `compressed` + `format`
+    //e.g. `color.image_raw.` + `theora` + `quality`
     std::string recommendedName = name.substr(0, paramNameIndex + 1) + transport + name.substr(paramNameIndex);
 
     rclcpp::Parameter recommendedValue = node_->get_parameter(recommendedName);

--- a/theora_image_transport/src/theora_subscriber.cpp
+++ b/theora_image_transport/src/theora_subscriber.cpp
@@ -294,12 +294,12 @@ void TheoraSubscriber::internalCallback(const theora_image_transport::msg::Packe
 void TheoraSubscriber::declareParameter(const std::string &base_name,
                                        const ParameterDefinition &definition)
 {
-  //transport scoped parameter (e.g. image_raw.compressed.format)
+  //transport scoped parameter (e.g. image_raw.theora.post_processing_level)
   const std::string transport_name = getTransportName();
   const std::string param_name = base_name + "." + transport_name + "." + definition.descriptor.name;
   parameters_.push_back(param_name);
 
-  //deprecated non-scoped parameter name (e.g. image_raw.format)
+  //deprecated non-scoped parameter name (e.g. image_raw.post_processing_level)
   const std::string deprecated_name = base_name + "." + definition.descriptor.name;
   deprecatedParameters_.push_back(deprecated_name);
 
@@ -341,7 +341,7 @@ void TheoraSubscriber::onParameterEvent(ParameterEvent::SharedPtr event, std::st
 
     size_t baseNameIndex = name.find(base_name); //name was generated from base_name, has to succeed
     size_t paramNameIndex = baseNameIndex + base_name.size();
-    //e.g. `color.image_raw.` + `compressed` + `format`
+    //e.g. `color.image_raw.` + `theora` + `post_processing_level`
     std::string recommendedName = name.substr(0, paramNameIndex + 1) + transport + name.substr(paramNameIndex);
 
     rclcpp::Parameter recommendedValue = node_->get_parameter(recommendedName);


### PR DESCRIPTION
#140 fix for theora_image_transport (publisher and subscriber)
#108 like (runtime reconfigurable)

Implementation is #143 like + minor deviation for publisher.

The original logic behind dynamic reconfigure callbacks was kept.

## publisher notes

The publisher is more complex here
- in general we reload config on publish
- but some code paths (conditional compilation)
  - would result in resetting theora context on every config reload
    - so we flag to reload config only on parameter event change
      - and reload it also once on init to mimic ROS1 dynamic reconfigure setup

This is different from all other transport scoped changes so far where we could make transport reconfigurable without depending on parameter event monitoring (in the spirit of #108).

The difference is only in setting/resetting/checking flag but event handling code exists only for the purpose of deprecated parameters in other transports.

## code repetition

There is some code repetition between:
- compressed_image_transport
- compressed_depth_image_transport
- theora_image_transport

This should be temporary until deprecated parameters are removed.

The way to proceed was sketched in:
- https://github.com/ros-perception/image_transport_plugins/issues/140#issuecomment-1525806469