### PR TITLE
Disabling class_loader_hide_library_symbols()

### DIFF
--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(${PROJECT_NAME} ${SOURCE_FILES})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
 
-class_loader_hide_library_symbols(${PROJECT_NAME})
+#class_loader_hide_library_symbols(${PROJECT_NAME})
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
We need to call the _**CompressRVL()**_ and **_DecompressRVL()_** functions directly. We need this as we would like to do the compression and publishing at different times/from different threads for performance issues. Disabling **_class_loader_hide_library_symbols()_** in the CMakeLists.txt would enable us to do this. 