### PR TITLE
Add RVL support for compressed depth image transport

### DIFF
--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(
     SHARED
     src/compressed_depth_publisher.cpp
     src/compressed_depth_subscriber.cpp
-    src/manifest.cpp src/codec.cpp
+    src/manifest.cpp src/codec.cpp src/rvl_codec.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES})

--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -50,4 +50,11 @@ install(
 pluginlib_export_plugin_description_file(image_transport
     compressed_depth_plugins.xml)
 
+# Test
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(rvl_codec_test test/rvl_codec_test.cpp)
+  target_link_libraries(rvl_codec_test ${PROJECT_NAME})
+endif()
+
 ament_package()

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
@@ -47,10 +47,10 @@ namespace compressed_depth_image_transport
 sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
   const sensor_msgs::msg::CompressedImage& compressed_image);
 
-// Compress a depth image. The png_compression parameter is passed straight through to
-// OpenCV as IMWRITE_PNG_COMPRESSION. Returns a null pointer on bad input.
+// Compress a depth image. Returns a null pointer on bad input.
 sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
   const sensor_msgs::msg::Image& message,
+  const std::string& compression_format = "png",
   double depth_max = 10.0,
   double depth_quantization = 100.0,
   int png_level = 9);

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.h
@@ -50,7 +50,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
 // Compress a depth image. Returns a null pointer on bad input.
 sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
   const sensor_msgs::msg::Image& message,
-  const std::string& compression_format = "png",
+  const std::string& format = "png",
   double depth_max = 10.0,
   double depth_quantization = 100.0,
   int png_level = 9);

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/rvl_codec.h
@@ -1,0 +1,33 @@
+#ifndef COMPRESSED_DEPTH_IMAGE_TRANSPORT_RVL_CODEC_H_
+#define COMPRESSED_DEPTH_IMAGE_TRANSPORT_RVL_CODEC_H_
+
+namespace compressed_depth_image_transport {
+
+class RvlCodec {
+ public:
+  RvlCodec();
+  // Compress input data into output. The size of output can be equal to
+  // (1.5 * numPixels + 4) in the worst case.
+  int CompressRVL(const unsigned short* input, unsigned char* output,
+                  int numPixels);
+  // Decompress input data into output. The size of output must be
+  // equal to numPixels.
+  void DecompressRVL(const unsigned char* input, unsigned short* output,
+                     int numPixels);
+
+ private:
+  RvlCodec(const RvlCodec&);
+  RvlCodec& operator=(const RvlCodec&);
+
+  void EncodeVLE(int value);
+  int DecodeVLE();
+
+  int *buffer_;
+  int *pBuffer_;
+  int word_;
+  int nibblesWritten_;
+};
+
+}  // namespace compressed_depth_image_transport
+
+#endif  // COMPRESSED_DEPTH_IMAGE_TRANSPORT_RVL_CODEC_H_

--- a/compressed_depth_image_transport/package.xml
+++ b/compressed_depth_image_transport/package.xml
@@ -17,6 +17,8 @@
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
     <image_transport plugin="${prefix}/compressed_depth_plugins.xml" />

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -39,10 +39,12 @@
 
 #include "cv_bridge/cv_bridge.hpp"
 #include <opencv2/imgcodecs.hpp>
-#include <rclcpp/logging.hpp>
+#include "rclcpp/clock.hpp"
+#include "rclcpp/logging.hpp"
 
 #include "compressed_depth_image_transport/codec.h"
 #include "compressed_depth_image_transport/compression_common.h"
+#include "compressed_depth_image_transport/rvl_codec.h"
 
 // If OpenCV3
 #ifndef CV_VERSION_EPOCH
@@ -63,12 +65,32 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
   cv_bridge::CvImagePtr cv_ptr(new cv_bridge::CvImage);
 
   auto logger = rclcpp::get_logger("compressed_depth_image_transport");
+  auto clock = rclcpp::Clock();
 
   // Copy message header
   cv_ptr->header = message.header;
 
   // Assign image encoding
-  std::string image_encoding = message.format.substr(0, message.format.find(';'));
+  const size_t split_pos = message.format.find(';');
+  const std::string image_encoding = message.format.substr(0, split_pos);
+  std::string compression_format;
+  // Older version of compressed_depth_image_transport supports only png.
+  if (split_pos == std::string::npos) {
+    compression_format = "png";
+  } else {
+    std::string format = message.format.substr(split_pos);
+    if (format.find("compressedDepth png") != std::string::npos) {
+      compression_format = "png";
+    } else if (format.find("compressedDepth rvl") != std::string::npos) {
+      compression_format = "rvl";
+    } else if (format.find("compressedDepth") != std::string::npos && format.find("compressedDepth ") == std::string::npos) {
+      compression_format = "png";
+    } else {
+      RCLCPP_ERROR(logger, "Unsupported image format: %s", message.format.c_str());
+      return sensor_msgs::msg::Image::SharedPtr();
+    }
+  }
+
   cv_ptr->encoding = image_encoding;
 
   // Decode message data
@@ -92,14 +114,44 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
     if (enc::bitDepth(image_encoding) == 32)
     {
       cv::Mat decompressed;
-      try
-      {
-        // Decode image data
-        decompressed = cv::imdecode(imageData, cv::IMREAD_UNCHANGED);
-      }
-      catch (cv::Exception& e)
-      {
-        RCLCPP_ERROR(logger, e.what());
+      if (compression_format == "png") {
+        try
+        {
+          // Decode image data
+          decompressed = cv::imdecode(imageData, cv::IMREAD_UNCHANGED);
+        }
+        catch (cv::Exception& e)
+        {
+          RCLCPP_ERROR(logger, e.what());
+          return sensor_msgs::msg::Image::SharedPtr();
+        }
+      } else if (compression_format == "rvl") {
+        const unsigned char *buffer = imageData.data();
+
+        uint32_t cols, rows;
+        memcpy(&cols, &buffer[0], 4);
+        memcpy(&rows, &buffer[4], 4);
+        if (rows == 0 || cols == 0)
+        {
+          RCLCPP_ERROR_THROTTLE(logger, clock, 1.0, "Received malformed RVL-encoded image. Size %ix%i contains zero.", cols, rows);
+          return sensor_msgs::msg::Image::SharedPtr();
+        }
+
+        // Sanity check - the best compression ratio is 4x; we leave some buffer, so we check whether the output image would
+        // not be more than 10x larger than the compressed one. If it is, we probably received corrupted data.
+        // The condition should be "numPixels * 2 > compressed.size() * 10" (because each pixel is 2 bytes), but to prevent
+        // overflow, we have canceled out the *2 from both sides of the inequality.
+        const auto numPixels = static_cast<uint64_t>(rows) * cols;
+        if (numPixels > std::numeric_limits<int>::max() || numPixels > static_cast<uint64_t>(imageData.size()) * 5)
+        {
+          RCLCPP_ERROR_THROTTLE(logger, clock, 1.0, "Received malformed RVL-encoded image. It reports size %ux%u.", cols, rows);
+          return sensor_msgs::msg::Image::SharedPtr();
+        }
+
+        decompressed = Mat(rows, cols, CV_16UC1);
+        RvlCodec rvl;
+        rvl.DecompressRVL(&buffer[8], decompressed.ptr<unsigned short>(), cols * rows);
+      } else {
         return sensor_msgs::msg::Image::SharedPtr();
       }
 
@@ -136,13 +188,25 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
     else
     {
       // Decode raw image
-      try
-      {
-        cv_ptr->image = cv::imdecode(imageData, cv::IMREAD_UNCHANGED);
-      }
-      catch (cv::Exception& e)
-      {
-        RCLCPP_ERROR(logger, e.what());
+      if (compression_format == "png") {
+        try
+        {
+          cv_ptr->image = cv::imdecode(imageData, cv::IMREAD_UNCHANGED);
+        }
+        catch (cv::Exception& e)
+        {
+          RCLCPP_ERROR(logger, e.what());
+          return sensor_msgs::msg::Image::SharedPtr();
+        }
+      } else if (compression_format == "rvl") {
+        const unsigned char *buffer = imageData.data();
+        uint32_t cols, rows;
+        memcpy(&cols, &buffer[0], 4);
+        memcpy(&rows, &buffer[4], 4);
+        cv_ptr->image = Mat(rows, cols, CV_16UC1);
+        RvlCodec rvl;
+        rvl.DecompressRVL(&buffer[8], cv_ptr->image.ptr<unsigned short>(), cols * rows);
+      } else {
         return sensor_msgs::msg::Image::SharedPtr();
       }
 
@@ -161,6 +225,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
 
 sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
   const sensor_msgs::msg::Image& message,
+  const std::string& compression_format,
   double depth_max,
   double depth_quantization,
   int png_level)
@@ -188,7 +253,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
   std::vector<uint8_t> compressedImage;
 
   // Update ros message format header
-  compressed->format += "; compressedDepth";
+  compressed->format += "; compressedDepth " + compression_format;
 
   // Check input format
   params[0] = cv::IMWRITE_PNG_COMPRESSION;
@@ -248,26 +313,40 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
       compressionConfig.depthParam[0] = depthQuantA;
       compressionConfig.depthParam[1] = depthQuantB;
 
-      try
-      {
-        // Compress quantized disparity image
-        if (cv::imencode(".png", invDepthImg, compressedImage, params))
+      // Compress quantized disparity image
+      if (compression_format == "png") {
+        try
         {
-          float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
-              / (float)compressedImage.size();
-          RCLCPP_DEBUG(logger,
-                       "Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
+          // Compress quantized disparity image
+          if (cv::imencode(".png", invDepthImg, compressedImage, params))
+          {
+            float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
+                / (float)compressedImage.size();
+            RCLCPP_DEBUG(logger,
+                         "Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
+          }
+          else
+          {
+            RCLCPP_ERROR(logger, "cv::imencode (png) failed on input image");
+            return sensor_msgs::msg::CompressedImage::SharedPtr();
+          }
         }
-        else
+        catch (cv::Exception& e)
         {
-          RCLCPP_ERROR(logger, "cv::imencode (png) failed on input image");
+          RCLCPP_ERROR(logger, e.msg.c_str());
           return sensor_msgs::msg::CompressedImage::SharedPtr();
         }
-      }
-      catch (cv::Exception& e)
-      {
-        RCLCPP_ERROR(logger, e.msg.c_str());
-        return sensor_msgs::msg::CompressedImage::SharedPtr();
+      } else if (compression_format == "rvl") {
+        int numPixels = invDepthImg.rows * invDepthImg.cols;
+        // In the worst case, RVL compression results in ~1.5x larger data.
+        compressedImage.resize(3 * numPixels + 12);
+        uint32_t cols = invDepthImg.cols;
+        uint32_t rows = invDepthImg.rows;
+        memcpy(&compressedImage[0], &cols, 4);
+        memcpy(&compressedImage[4], &rows, 4);
+        RvlCodec rvl;
+        int compressedSize = rvl.CompressRVL(invDepthImg.ptr<unsigned short>(), &compressedImage[8], numPixels);
+        compressedImage.resize(8 + compressedSize);
       }
     }
   }
@@ -306,17 +385,30 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
       }
 
       // Compress raw depth image
-      if (cv::imencode(".png", cv_ptr->image, compressedImage, params))
-      {
-        float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
-            / (float)compressedImage.size();
-        RCLCPP_DEBUG(logger,
-          "Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
-      }
-      else
-      {
-        RCLCPP_ERROR(logger, "cv::imencode (png) failed on input image");
-        return sensor_msgs::msg::CompressedImage::SharedPtr();
+      if (compression_format == "png") {
+        if (cv::imencode(".png", cv_ptr->image, compressedImage, params))
+        {
+          float cRatio = (float)(cv_ptr->image.rows * cv_ptr->image.cols * cv_ptr->image.elemSize())
+              / (float)compressedImage.size();
+          RCLCPP_DEBUG(logger,
+            "Compressed Depth Image Transport - Compression: 1:%.2f (%lu bytes)", cRatio, compressedImage.size());
+        }
+        else
+        {
+          RCLCPP_ERROR(logger, "cv::imencode (png) failed on input image");
+          return sensor_msgs::msg::CompressedImage::SharedPtr();
+        }
+      } else if (compression_format == "rvl") {
+        int numPixels = cv_ptr->image.rows * cv_ptr->image.cols;
+        // In the worst case, RVL compression results in ~1.5x larger data.
+        compressedImage.resize(3 * numPixels + 12);
+        uint32_t cols = cv_ptr->image.cols;
+        uint32_t rows = cv_ptr->image.rows;
+        memcpy(&compressedImage[0], &cols, 4);
+        memcpy(&compressedImage[4], &rows, 4);
+        RvlCodec rvl;
+        int compressedSize = rvl.CompressRVL(cv_ptr->image.ptr<unsigned short>(), &compressedImage[8], numPixels);
+        compressedImage.resize(8 + compressedSize);
       }
     }
   }

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -44,13 +44,23 @@ namespace compressed_depth_image_transport
 
 enum compressedDepthParameters
 {
-  DEPTH_MAX = 0,
+  COMPRESSION_FORMAT = 0,
+  DEPTH_MAX,
   DEPTH_QUANTIZATION,
   PNG_LEVEL
 };
 
 const struct ParameterDefinition kParameters[] =
 {
+  { //COMPRESSION_FORMAT - The format of compression ("png" or "rvl")
+    ParameterValue("png"),
+    ParameterDescriptor()
+      .set__name("compression_format")
+      .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_STRING)
+      .set__description("Compression format")
+      .set__read_only(false)
+      .set__additional_constraints("Allowed values: [\"png\", \"rvl\"]")
+  },
   { //DEPTH_MAX - Maximum depth value (meter)
     ParameterValue((double)10.0),
     ParameterDescriptor()
@@ -123,12 +133,14 @@ void CompressedDepthPublisher::publish(
   const PublishFn& publish_fn) const
 {
   // Fresh Configuration
+  std::string cfg_compression_format = node_->get_parameter(parameters_[COMPRESSION_FORMAT]).get_value<std::string>();
   double cfg_depth_max = node_->get_parameter(parameters_[DEPTH_MAX]).get_value<double>();
   double cfg_depth_quantization = node_->get_parameter(parameters_[DEPTH_QUANTIZATION]).get_value<double>();
   int cfg_png_level = node_->get_parameter(parameters_[PNG_LEVEL]).get_value<int64_t>();
 
   sensor_msgs::msg::CompressedImage::SharedPtr compressed_image =
     encodeCompressedDepthImage(message,
+                               cfg_compression_format,
                                cfg_depth_max,
                                cfg_depth_quantization,
                                cfg_png_level);

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -44,7 +44,7 @@ namespace compressed_depth_image_transport
 
 enum compressedDepthParameters
 {
-  COMPRESSION_FORMAT = 0,
+  FORMAT = 0,
   DEPTH_MAX,
   DEPTH_QUANTIZATION,
   PNG_LEVEL
@@ -52,14 +52,14 @@ enum compressedDepthParameters
 
 const struct ParameterDefinition kParameters[] =
 {
-  { //COMPRESSION_FORMAT - The format of compression ("png" or "rvl")
+  { //FORMAT - Compression format to use "png" or "rvl".
     ParameterValue("png"),
     ParameterDescriptor()
-      .set__name("compression_format")
+      .set__name("format")
       .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_STRING)
-      .set__description("Compression format")
+      .set__description("Compression method")
       .set__read_only(false)
-      .set__additional_constraints("Allowed values: [\"png\", \"rvl\"]")
+      .set__additional_constraints("Supported values: [png, rvl]")
   },
   { //DEPTH_MAX - Maximum depth value (meter)
     ParameterValue((double)10.0),
@@ -133,14 +133,14 @@ void CompressedDepthPublisher::publish(
   const PublishFn& publish_fn) const
 {
   // Fresh Configuration
-  std::string cfg_compression_format = node_->get_parameter(parameters_[COMPRESSION_FORMAT]).get_value<std::string>();
+  std::string cfg_format = node_->get_parameter(parameters_[FORMAT]).get_value<std::string>();
   double cfg_depth_max = node_->get_parameter(parameters_[DEPTH_MAX]).get_value<double>();
   double cfg_depth_quantization = node_->get_parameter(parameters_[DEPTH_QUANTIZATION]).get_value<double>();
   int cfg_png_level = node_->get_parameter(parameters_[PNG_LEVEL]).get_value<int64_t>();
 
   sensor_msgs::msg::CompressedImage::SharedPtr compressed_image =
     encodeCompressedDepthImage(message,
-                               cfg_compression_format,
+                               cfg_format,
                                cfg_depth_max,
                                cfg_depth_quantization,
                                cfg_png_level);

--- a/compressed_depth_image_transport/src/rvl_codec.cpp
+++ b/compressed_depth_image_transport/src/rvl_codec.cpp
@@ -1,0 +1,92 @@
+// The following code is a C++ wrapper of the code presented by
+// Andrew D. Wilson in "Fast Lossless Depth Image Compression" at SIGCHI'17.
+// The original code is licensed under the MIT License.
+
+#include "compressed_depth_image_transport/rvl_codec.h"
+
+namespace compressed_depth_image_transport {
+
+RvlCodec::RvlCodec() {}
+
+void RvlCodec::EncodeVLE(int value) {
+  do {
+    int nibble = value & 0x7;        // lower 3 bits
+    if (value >>= 3) nibble |= 0x8;  // more to come
+    word_ <<= 4;
+    word_ |= nibble;
+    if (++nibblesWritten_ == 8)  // output word
+    {
+      *pBuffer_++ = word_;
+      nibblesWritten_ = 0;
+      word_ = 0;
+    }
+  } while (value);
+}
+
+int RvlCodec::DecodeVLE() {
+  unsigned int nibble;
+  int value = 0, bits = 29;
+  do {
+    if (!nibblesWritten_) {
+      word_ = *pBuffer_++;  // load word
+      nibblesWritten_ = 8;
+    }
+    nibble = word_ & 0xf0000000;
+    value |= (nibble << 1) >> bits;
+    word_ <<= 4;
+    nibblesWritten_--;
+    bits -= 3;
+  } while (nibble & 0x80000000);
+  return value;
+}
+
+int RvlCodec::CompressRVL(const unsigned short* input, unsigned char* output,
+                          int numPixels) {
+  buffer_ = pBuffer_ = (int*)output;
+  nibblesWritten_ = 0;
+  const unsigned short* end = input + numPixels;
+  unsigned short previous = 0;
+  while (input != end) {
+    int zeros = 0, nonzeros = 0;
+    for (; (input != end) && !*input; input++, zeros++)
+      ;
+    EncodeVLE(zeros);  // number of zeros
+    for (const unsigned short* p = input; (p != end) && *p++; nonzeros++)
+      ;
+    EncodeVLE(nonzeros);  // number of nonzeros
+    for (int i = 0; i < nonzeros; i++) {
+      unsigned short current = *input++;
+      int delta = current - previous;
+      int positive = (delta << 1) ^ (delta >> 31);
+      EncodeVLE(positive);  // nonzero value
+      previous = current;
+    }
+  }
+  if (nibblesWritten_)  // last few values
+    *pBuffer_++ = word_ << 4 * (8 - nibblesWritten_);
+  return int((unsigned char*)pBuffer_ - (unsigned char*)buffer_);  // num bytes
+}
+
+void RvlCodec::DecompressRVL(const unsigned char* input, unsigned short* output,
+                             int numPixels) {
+  buffer_ = pBuffer_ = const_cast<int*>(reinterpret_cast<const int*>(input));
+  nibblesWritten_ = 0;
+  unsigned short current, previous = 0;
+  int numPixelsToDecode = numPixels;
+  while (numPixelsToDecode) {
+    int zeros = DecodeVLE();  // number of zeros
+    numPixelsToDecode -= zeros;
+    for (; zeros; zeros--) *output++ = 0;
+    int nonzeros = DecodeVLE();  // number of nonzeros
+    numPixelsToDecode -= nonzeros;
+    for (; nonzeros; nonzeros--) {
+      int positive = DecodeVLE();  // nonzero value
+      int delta = (positive >> 1) ^ -(positive & 1);
+      current = previous + delta;
+      *output++ = current;
+      previous = current;
+    }
+  }
+}
+
+}  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/test/rvl_codec_test.cpp
+++ b/compressed_depth_image_transport/test/rvl_codec_test.cpp
@@ -1,0 +1,56 @@
+#include "compressed_depth_image_transport/rvl_codec.h"
+#include <gtest/gtest.h>
+
+TEST(RvlCodecTest, reciprocalTestEmpty) {
+  const int size = 1000000;
+  std::vector<unsigned short> original(size);
+  std::vector<unsigned char> compressed(3 * size + 4);
+  std::vector<unsigned short> decompressed(size);
+  compressed_depth_image_transport::RvlCodec rvl;
+
+  // Constant depth.
+  const int validDepth = 42;
+  std::fill(original.begin(), original.end(), validDepth);
+  rvl.CompressRVL(&original[0], &compressed[0], size);
+  rvl.DecompressRVL(&compressed[0], &decompressed[0], size);
+  EXPECT_TRUE(std::equal(original.begin(), original.end(), decompressed.begin()));
+
+  // Totally invalid depth.
+  const int invalidDepth = 0;
+  std::fill(original.begin(), original.end(), invalidDepth);
+  rvl.CompressRVL(&original[0], &compressed[0], size);
+  rvl.DecompressRVL(&compressed[0], &decompressed[0], size);
+  EXPECT_TRUE(std::equal(original.begin(), original.end(), decompressed.begin()));
+
+  // Empty depth.
+  EXPECT_EQ(rvl.CompressRVL(NULL, NULL, 0), 0);
+  rvl.DecompressRVL(NULL, NULL, 0);  // should not die.
+}
+
+TEST(RvlCodecTest, reciprocalTestRandom) {
+  const int size = 1000000;
+  std::vector<unsigned short> original(size);
+  std::vector<unsigned char> compressed(3 * size + 4);
+  std::vector<unsigned short> decompressed(size);
+  compressed_depth_image_transport::RvlCodec rvl;
+
+  // Populate depths with random size of runs with random values.
+  for (int i = 0; i < size;) {
+    int length = std::min<int>(rand() % 10, size - i);
+    int value = rand() % 10;
+    std::fill(&original[i], &original[i] + length, value);
+    i += length;
+  }
+
+  const int compressedSize =
+      rvl.CompressRVL(&original[0], &compressed[0], size);
+  EXPECT_GT(compressedSize, 0);
+  EXPECT_LT(compressedSize, compressed.size());
+  rvl.DecompressRVL(&compressed[0], &decompressed[0], size);
+  EXPECT_TRUE(std::equal(original.begin(), original.end(), decompressed.begin()));
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This builds upon @anilsripadarao 's PR #153 and supersedes it to add RVL codec as a possible way of encoding compressed depth images.

This is a forward port of a functionality available in ROS 1, introduced in https://github.com/ros-perception/image_transport_plugins/pull/42 and some follow up PRs. Minimal changes are made to the implementation.

To use, simply set the .compressedDepth.format parmeter via:
`ros2 param set <node> <image_topic>.compressedDepth.format rvl`

