### PR TITLE
Fix out-of-range exception

### DIFF
--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -115,8 +115,10 @@ void CompressedDepthPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
-  std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  if (base_topic.length() >= ns_len) {
+    std::string param_base_name = base_topic.substr(ns_len);
+    std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  }
 
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;
   auto callback = std::bind(&CompressedDepthPublisher::onParameterEvent, this, std::placeholders::_1,

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -141,8 +141,10 @@ void CompressedPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
-  std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  if (base_topic.length() >= ns_len) {
+    std::string param_base_name = base_topic.substr(ns_len);
+    std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  }
 
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;
   auto callback = std::bind(&CompressedPublisher::onParameterEvent, this, std::placeholders::_1,

--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -88,8 +88,10 @@ void CompressedSubscriber::subscribeImpl(
 
     // Declare Parameters
     uint ns_len = node->get_effective_namespace().length();
-    std::string param_base_name = base_topic.substr(ns_len);
-    std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+    if (base_topic.length() >= ns_len) {
+      std::string param_base_name = base_topic.substr(ns_len);
+      std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+    }
 
     using paramCallbackT = std::function<void(ParameterEvent::SharedPtr event)>;
     auto paramCallback = std::bind(&CompressedSubscriber::onParameterEvent, this, std::placeholders::_1,

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -157,8 +157,10 @@ void TheoraPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
-  std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  if (base_topic.length() >= ns_len) {
+    std::string param_base_name = base_topic.substr(ns_len);
+    std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  }
 
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;
   auto callback = std::bind(&TheoraPublisher::onParameterEvent, this, std::placeholders::_1,

--- a/theora_image_transport/src/theora_subscriber.cpp
+++ b/theora_image_transport/src/theora_subscriber.cpp
@@ -107,8 +107,10 @@ void TheoraSubscriber::subscribeImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
-  std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  if (base_topic.length() >= ns_len) {
+    std::string param_base_name = base_topic.substr(ns_len);
+    std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  }
 
   using paramCallbackT = std::function<void(ParameterEvent::SharedPtr event)>;
   auto paramCallback = std::bind(&TheoraSubscriber::onParameterEvent, this, std::placeholders::_1,

--- a/zstd_image_transport/src/zstd_publisher.cpp
+++ b/zstd_image_transport/src/zstd_publisher.cpp
@@ -84,8 +84,10 @@ void ZstdPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
-  std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  if (base_topic.length() >= ns_len) {
+    std::string param_base_name = base_topic.substr(ns_len);
+    std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
+  }
 
   for (const ParameterDefinition & pd : kParameters) {
     declareParameter(param_base_name, pd);


### PR DESCRIPTION
When using relative topic name to subscribe, and the name is shorter than namespace, it will lead to out-of-range exception.
This PR is to fix it.

**Backport to older version needed!!!**