### PR TITLE
Include alpha channel in PNG compression

### DIFF
--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -254,7 +254,11 @@ void CompressedPublisher::publish(
           std::stringstream targetFormat;
           if (enc::isColor(message.encoding)) {
           // convert color images to RGB domain
-            targetFormat << "bgr" << bitDepth;
+            targetFormat << "bgr";
+            if (enc::hasAlpha(message.encoding)) {
+              targetFormat << "a";
+            }
+            targetFormat << bitDepth;
             compressed.format += targetFormat.str();
           }
 


### PR DESCRIPTION
Right now PNG compression checked only for the color channels and included them in the target format.
This pull request adds also checking and adding alpha channel to the format if the image message has alpha channel.