### PR TITLE
compressed_depth_image_transport: use RVL by default

### DIFF
--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -53,7 +53,7 @@ enum compressedDepthParameters
 const struct ParameterDefinition kParameters[] =
 {
   {  // FORMAT - Compression format to use "png" or "rvl".
-    ParameterValue("png"),
+    ParameterValue("rvl"),
     ParameterDescriptor()
     .set__name("format")
     .set__type(rcl_interfaces::msg::ParameterType::PARAMETER_STRING)


### PR DESCRIPTION
I have changed the default depth compression codec from PNG to RVL, which will make the plugin work much better out of the box.

PNG encoding is extremely slow and computationally demanding, which makes it completely unsuitable for real-time streaming in scenarios where a more complex image processing pipeline is used.

On the other hand, RVL compression works extremely well and has very little overhead. In fact, according to the original paper by Microsoft Research, their algorithm is superior to PNG in every possible way:

![image](https://github.com/user-attachments/assets/eb692649-1149-475d-8baf-ffce49011024)

Other than than, there's a bit of a hassle in setting up all your publishers to use RVL, because every single one of them separately needs a properly namespaced parameter to be set.

You might have wanted to keep the defaults unchanged to keep backwards compatibility with code that expects `image_raw/compressedDepth` to be a PNG-encoded `sensor_msgs/CompressedImage`, but such code must obviously have been written the wrong way, because normally an image_transport subscriber would automatically apply the right decompression method, which is the case for most existing code.
 
Given all the above, I don't see a reason why RVL should not be the default.