### PR TITLE
Fix inconsistent parameter names when running under a namespace

### DIFF
--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.hpp
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.hpp
@@ -86,8 +86,7 @@ private:
     const std::string & base_name,
     const ParameterDefinition & definition);
 
-  void preSetParametersCallback(
-    std::vector<rclcpp::Parameter> & parameters, std::string base_name);
+  void preSetParametersCallback(std::vector<rclcpp::Parameter> & parameters);
 };
 
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.hpp
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/compressed_depth_publisher.hpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
@@ -76,10 +77,17 @@ protected:
 
 private:
   std::vector<std::string> parameters_;
+  std::unordered_set<std::string> deprecated_parameters_;
+
+  rclcpp::node_interfaces::PreSetParametersCallbackHandle::SharedPtr
+    pre_set_parameter_callback_handle_;
 
   void declareParameter(
     const std::string & base_name,
     const ParameterDefinition & definition);
+
+  void preSetParametersCallback(
+    std::vector<rclcpp::Parameter> & parameters, std::string base_name);
 };
 
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -115,7 +115,8 @@ void CompressedDepthPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
+  uint ns_prefix_len = ns_len > 1 ? ns_len + 1 : ns_len;
+  std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   for(const ParameterDefinition & pd : kParameters) {

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -119,11 +119,13 @@ void CompressedDepthPublisher::advertiseImpl(
   std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
-  // Add pre set parameter callback to handle deprecated parameters
-  pre_set_parameter_callback_handle_ =
-    node->add_pre_set_parameters_callback(std::bind(
-      &CompressedDepthPublisher::preSetParametersCallback,
-      this, std::placeholders::_1, param_base_name));
+  if (ns_len > 1) {
+    // Add pre set parameter callback to handle deprecated parameters
+    pre_set_parameter_callback_handle_ =
+      node->add_pre_set_parameters_callback(std::bind(
+      &CompressedDepthPublisher::preSetParametersCallback, this, std::placeholders::_1,
+        param_base_name));
+  }
 
   for(const ParameterDefinition & pd : kParameters) {
     declareParameter(param_base_name, pd);

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -123,8 +123,7 @@ void CompressedDepthPublisher::advertiseImpl(
     // Add pre set parameter callback to handle deprecated parameters
     pre_set_parameter_callback_handle_ =
       node->add_pre_set_parameters_callback(std::bind(
-      &CompressedDepthPublisher::preSetParametersCallback, this, std::placeholders::_1,
-        param_base_name));
+      &CompressedDepthPublisher::preSetParametersCallback, this, std::placeholders::_1));
   }
 
   for(const ParameterDefinition & pd : kParameters) {
@@ -189,38 +188,30 @@ void CompressedDepthPublisher::declareParameter(
 }
 
 void CompressedDepthPublisher::preSetParametersCallback(
-  std::vector<rclcpp::Parameter> & parameters, std::string base_name)
+  std::vector<rclcpp::Parameter> & parameters)
 {
+  std::vector<rclcpp::Parameter> new_parameters;
+
   for (auto & param : parameters) {
-    // Check if parameter is deprecated
-    if (deprecated_parameters_.find(param.get_name()) != deprecated_parameters_.end()) {
-      // name was generated from base_name, has to succeed
-      size_t base_name_index = param.get_name().find(base_name);
-      size_t param_name_index = base_name_index + base_name.size();
+    const auto & param_name = param.get_name();
 
-      // Check if scoped parameter name
-      if (param.get_name().substr(param_name_index + 1, getTransportName().size()) ==
-        getTransportName())
-      {
-        param_name_index += getTransportName().size() + 1;
-      }
-
-      std::string recommended_name = base_name + "." + getTransportName() + "." +
-        param.get_name().substr(param_name_index + 1);
-
-      rclcpp::Parameter recommended_value = node_->get_parameter(recommended_name);
-
-      // do not emit warnings if deprecated value matches
-      if (param.get_value_message() == recommended_value.get_value_message()) {
-        continue;
-      }
-
+    // Check if this is a deprecated dot-prefixed parameter for our transport
+    if (deprecated_parameters_.find(param_name) != deprecated_parameters_.end()) {
+      auto non_dot_prefixed_name = param_name.substr(1);
       RCLCPP_WARN_STREAM(logger_,
-          "parameter `" << param.get_name() << "` is deprecated; use canonical name: `" <<
-          recommended_name << "`");
+            "parameter `" << param_name << "` with leading dot character is deprecated; use: `" <<
+            non_dot_prefixed_name << "` instead");
+      new_parameters.push_back(
+          rclcpp::Parameter(non_dot_prefixed_name, param.get_parameter_value()));
+    }
 
-      parameters.push_back(rclcpp::Parameter(recommended_name, param.get_parameter_value()));
+    // Check if this is a normal parameter for our transport
+    if (std::find(parameters_.begin(), parameters_.end(), param_name) != parameters_.end()) {
+      // Also update the dot-prefixed parameter
+      new_parameters.emplace_back("." + param_name, param.get_parameter_value());
     }
   }
+
+  parameters.insert(parameters.end(), new_parameters.begin(), new_parameters.end());
 }
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -119,6 +119,12 @@ void CompressedDepthPublisher::advertiseImpl(
   std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
+  // Add pre set parameter callback to handle deprecated parameters
+  pre_set_parameter_callback_handle_ =
+    node->add_pre_set_parameters_callback(std::bind(
+      &CompressedDepthPublisher::preSetParametersCallback,
+      this, std::placeholders::_1, param_base_name));
+
   for(const ParameterDefinition & pd : kParameters) {
     declareParameter(param_base_name, pd);
   }
@@ -164,6 +170,55 @@ void CompressedDepthPublisher::declareParameter(
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
     param_value = node_->get_parameter(param_name).get_parameter_value();
+  }
+
+  if (node_->get_effective_namespace().length() > 1) {
+    // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
+    const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +
+      definition.descriptor.name;
+    deprecated_parameters_.insert(deprecated_dot_name);
+
+    try {
+      node_->declare_parameter(deprecated_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
+  }
+}
+
+void CompressedDepthPublisher::preSetParametersCallback(
+  std::vector<rclcpp::Parameter> & parameters, std::string base_name)
+{
+  for (auto & param : parameters) {
+    // Check if parameter is deprecated
+    if (deprecated_parameters_.find(param.get_name()) != deprecated_parameters_.end()) {
+      // name was generated from base_name, has to succeed
+      size_t base_name_index = param.get_name().find(base_name);
+      size_t param_name_index = base_name_index + base_name.size();
+
+      // Check if scoped parameter name
+      if (param.get_name().substr(param_name_index + 1, getTransportName().size()) ==
+        getTransportName())
+      {
+        param_name_index += getTransportName().size() + 1;
+      }
+
+      std::string recommended_name = base_name + "." + getTransportName() + "." +
+        param.get_name().substr(param_name_index + 1);
+
+      rclcpp::Parameter recommended_value = node_->get_parameter(recommended_name);
+
+      // do not emit warnings if deprecated value matches
+      if (param.get_value_message() == recommended_value.get_value_message()) {
+        continue;
+      }
+
+      RCLCPP_WARN_STREAM(logger_,
+          "parameter `" << param.get_name() << "` is deprecated; use canonical name: `" <<
+          recommended_name << "`");
+
+      parameters.push_back(rclcpp::Parameter(recommended_name, param.get_parameter_value()));
+    }
   }
 }
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -173,6 +173,7 @@ void CompressedDepthPublisher::declareParameter(
     param_value = node_->get_parameter(param_name).get_parameter_value();
   }
 
+  // TODO(anyone): Remove deprecated parameters after Lyrical release
   if (node_->get_effective_namespace().length() > 1) {
     // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
     const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +

--- a/compressed_image_transport/include/compressed_image_transport/compressed_publisher.hpp
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_publisher.hpp
@@ -88,8 +88,7 @@ private:
     const std::string & base_name,
     const ParameterDefinition & definition);
 
-  void preSetParametersCallback(
-    std::vector<rclcpp::Parameter> & parameters, std::string base_name);
+  void preSetParametersCallback(std::vector<rclcpp::Parameter> & parameters);
 };
 }  // namespace compressed_image_transport
 

--- a/compressed_image_transport/include/compressed_image_transport/compressed_publisher.hpp
+++ b/compressed_image_transport/include/compressed_image_transport/compressed_publisher.hpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
@@ -78,10 +79,17 @@ protected:
 
 private:
   std::vector<std::string> parameters_;
+  std::unordered_set<std::string> deprecated_parameters_;
+
+  rclcpp::node_interfaces::PreSetParametersCallbackHandle::SharedPtr
+    pre_set_parameter_callback_handle_;
 
   void declareParameter(
     const std::string & base_name,
     const ParameterDefinition & definition);
+
+  void preSetParametersCallback(
+    std::vector<rclcpp::Parameter> & parameters, std::string base_name);
 };
 }  // namespace compressed_image_transport
 

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -150,8 +150,7 @@ void CompressedPublisher::advertiseImpl(
     // Add pre set parameter callback to handle deprecated parameters
     pre_set_parameter_callback_handle_ =
       node->add_pre_set_parameters_callback(std::bind(
-        &CompressedPublisher::preSetParametersCallback, this, std::placeholders::_1,
-        param_base_name));
+        &CompressedPublisher::preSetParametersCallback, this, std::placeholders::_1));
   }
 
   for(const ParameterDefinition & pd : kParameters) {
@@ -415,39 +414,30 @@ void CompressedPublisher::declareParameter(
   }
 }
 
-void CompressedPublisher::preSetParametersCallback(
-  std::vector<rclcpp::Parameter> & parameters, std::string base_name)
+void CompressedPublisher::preSetParametersCallback(std::vector<rclcpp::Parameter> & parameters)
 {
+  std::vector<rclcpp::Parameter> new_parameters;
+
   for (auto & param : parameters) {
-    // Check if parameter is deprecated
-    if (deprecated_parameters_.find(param.get_name()) != deprecated_parameters_.end()) {
-      // name was generated from base_name, has to succeed
-      size_t base_name_index = param.get_name().find(base_name);
-      size_t param_name_index = base_name_index + base_name.size();
+    const auto & param_name = param.get_name();
 
-      // Check if scoped parameter name
-      if (param.get_name().substr(param_name_index + 1, getTransportName().size()) ==
-        getTransportName())
-      {
-        param_name_index += getTransportName().size() + 1;
-      }
-
-      std::string recommended_name = base_name + "." + getTransportName() + "." +
-        param.get_name().substr(param_name_index + 1);
-
-      rclcpp::Parameter recommended_value = node_->get_parameter(recommended_name);
-
-      // do not emit warnings if deprecated value matches
-      if (param.get_value_message() == recommended_value.get_value_message()) {
-        continue;
-      }
-
+    // Check if this is a deprecated dot-prefixed parameter for our transport
+    if (deprecated_parameters_.find(param_name) != deprecated_parameters_.end()) {
+      auto non_dot_prefixed_name = param_name.substr(1);
       RCLCPP_WARN_STREAM(logger_,
-          "parameter `" << param.get_name() << "` is deprecated; use canonical name: `" <<
-          recommended_name << "`");
+            "parameter `" << param_name << "` with leading dot character is deprecated; use: `" <<
+            non_dot_prefixed_name << "` instead");
+      new_parameters.push_back(
+          rclcpp::Parameter(non_dot_prefixed_name, param.get_parameter_value()));
+    }
 
-      parameters.push_back(rclcpp::Parameter(recommended_name, param.get_parameter_value()));
+    // Check if this is a normal parameter for our transport
+    if (std::find(parameters_.begin(), parameters_.end(), param_name) != parameters_.end()) {
+      // Also update the dot-prefixed parameter
+      new_parameters.emplace_back("." + param_name, param.get_parameter_value());
     }
   }
+
+  parameters.insert(parameters.end(), new_parameters.begin(), new_parameters.end());
 }
 }  // namespace compressed_image_transport

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -146,10 +146,13 @@ void CompressedPublisher::advertiseImpl(
   std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
-  // Add pre set parameter callback to handle deprecated parameters
-  pre_set_parameter_callback_handle_ =
-    node->add_pre_set_parameters_callback(std::bind(&CompressedPublisher::preSetParametersCallback,
-      this, std::placeholders::_1, param_base_name));
+  if (ns_len > 1) {
+    // Add pre set parameter callback to handle deprecated parameters
+    pre_set_parameter_callback_handle_ =
+      node->add_pre_set_parameters_callback(std::bind(
+        &CompressedPublisher::preSetParametersCallback, this, std::placeholders::_1,
+        param_base_name));
+  }
 
   for(const ParameterDefinition & pd : kParameters) {
     declareParameter(param_base_name, pd);

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -146,6 +146,11 @@ void CompressedPublisher::advertiseImpl(
   std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
+  // Add pre set parameter callback to handle deprecated parameters
+  pre_set_parameter_callback_handle_ =
+    node->add_pre_set_parameters_callback(std::bind(&CompressedPublisher::preSetParametersCallback,
+      this, std::placeholders::_1, param_base_name));
+
   for(const ParameterDefinition & pd : kParameters) {
     declareParameter(param_base_name, pd);
   }
@@ -391,6 +396,55 @@ void CompressedPublisher::declareParameter(
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
     param_value = node_->get_parameter(param_name).get_parameter_value();
+  }
+
+  if (node_->get_effective_namespace().length() > 1) {
+    // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
+    const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +
+      definition.descriptor.name;
+    deprecated_parameters_.insert(deprecated_dot_name);
+
+    try {
+      node_->declare_parameter(deprecated_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
+  }
+}
+
+void CompressedPublisher::preSetParametersCallback(
+  std::vector<rclcpp::Parameter> & parameters, std::string base_name)
+{
+  for (auto & param : parameters) {
+    // Check if parameter is deprecated
+    if (deprecated_parameters_.find(param.get_name()) != deprecated_parameters_.end()) {
+      // name was generated from base_name, has to succeed
+      size_t base_name_index = param.get_name().find(base_name);
+      size_t param_name_index = base_name_index + base_name.size();
+
+      // Check if scoped parameter name
+      if (param.get_name().substr(param_name_index + 1, getTransportName().size()) ==
+        getTransportName())
+      {
+        param_name_index += getTransportName().size() + 1;
+      }
+
+      std::string recommended_name = base_name + "." + getTransportName() + "." +
+        param.get_name().substr(param_name_index + 1);
+
+      rclcpp::Parameter recommended_value = node_->get_parameter(recommended_name);
+
+      // do not emit warnings if deprecated value matches
+      if (param.get_value_message() == recommended_value.get_value_message()) {
+        continue;
+      }
+
+      RCLCPP_WARN_STREAM(logger_,
+          "parameter `" << param.get_name() << "` is deprecated; use canonical name: `" <<
+          recommended_name << "`");
+
+      parameters.push_back(rclcpp::Parameter(recommended_name, param.get_parameter_value()));
+    }
   }
 }
 }  // namespace compressed_image_transport

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -142,7 +142,8 @@ void CompressedPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
+  uint ns_prefix_len = ns_len > 1 ? ns_len + 1 : ns_len;
+  std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   for(const ParameterDefinition & pd : kParameters) {

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -400,6 +400,7 @@ void CompressedPublisher::declareParameter(
     param_value = node_->get_parameter(param_name).get_parameter_value();
   }
 
+  // TODO(anyone): Remove deprecated parameters after Lyrical release
   if (node_->get_effective_namespace().length() > 1) {
     // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
     const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +

--- a/theora_image_transport/include/theora_image_transport/theora_publisher.hpp
+++ b/theora_image_transport/include/theora_image_transport/theora_publisher.hpp
@@ -112,8 +112,8 @@ private:
 
   rclcpp::node_interfaces::PreSetParametersCallbackHandle::SharedPtr
     pre_set_parameter_callback_handle_;
-
-  rclcpp::Subscription<ParameterEvent>::SharedPtr parameter_subscription_;
+  rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr
+    post_set_parameter_callback_handle_;
 
   void declareParameter(
     const std::string & base_name,
@@ -122,9 +122,8 @@ private:
   void preSetParametersCallback(
     std::vector<rclcpp::Parameter> & parameters, std::string base_name);
 
-  void onParameterEvent(
-    ParameterEvent::SharedPtr event, std::string full_name,
-    std::string base_name);
+  void postSetParametersCallback(
+    const std::vector<rclcpp::Parameter> & parameters);
 };
 
 }  // namespace theora_image_transport

--- a/theora_image_transport/include/theora_image_transport/theora_publisher.hpp
+++ b/theora_image_transport/include/theora_image_transport/theora_publisher.hpp
@@ -119,8 +119,7 @@ private:
     const std::string & base_name,
     const ParameterDefinition & definition);
 
-  void preSetParametersCallback(
-    std::vector<rclcpp::Parameter> & parameters, std::string base_name);
+  void preSetParametersCallback(std::vector<rclcpp::Parameter> & parameters);
 
   void postSetParametersCallback(
     const std::vector<rclcpp::Parameter> & parameters);

--- a/theora_image_transport/include/theora_image_transport/theora_publisher.hpp
+++ b/theora_image_transport/include/theora_image_transport/theora_publisher.hpp
@@ -37,6 +37,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include <rclcpp/node.hpp>
 
@@ -107,13 +108,19 @@ protected:
 
 private:
   std::vector<std::string> parameters_;
-  std::vector<std::string> deprecatedParameters_;
+  std::unordered_set<std::string> deprecated_parameters_;
+
+  rclcpp::node_interfaces::PreSetParametersCallbackHandle::SharedPtr
+    pre_set_parameter_callback_handle_;
 
   rclcpp::Subscription<ParameterEvent>::SharedPtr parameter_subscription_;
 
   void declareParameter(
     const std::string & base_name,
     const ParameterDefinition & definition);
+
+  void preSetParametersCallback(
+    std::vector<rclcpp::Parameter> & parameters, std::string base_name);
 
   void onParameterEvent(
     ParameterEvent::SharedPtr event, std::string full_name,

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -158,6 +158,11 @@ void TheoraPublisher::advertiseImpl(
   std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
+  // Add pre set parameter callback to handle deprecated parameters
+  pre_set_parameter_callback_handle_ =
+    node->add_pre_set_parameters_callback(std::bind(&TheoraPublisher::preSetParametersCallback,
+      this, std::placeholders::_1, param_base_name));
+
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;
   auto callback = std::bind(&TheoraPublisher::onParameterEvent, this, std::placeholders::_1,
                             node->get_fully_qualified_name(), param_base_name);
@@ -434,6 +439,55 @@ void TheoraPublisher::declareParameter(
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
     param_value = node_->get_parameter(param_name).get_parameter_value();
+  }
+
+  if (node_->get_effective_namespace().length() > 1) {
+    // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
+    const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +
+      definition.descriptor.name;
+    deprecated_parameters_.insert(deprecated_dot_name);
+
+    try {
+      node_->declare_parameter(deprecated_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
+  }
+}
+
+void TheoraPublisher::preSetParametersCallback(
+  std::vector<rclcpp::Parameter> & parameters, std::string base_name)
+{
+  for (auto & param : parameters) {
+    // Check if parameter is deprecated
+    if (deprecated_parameters_.find(param.get_name()) != deprecated_parameters_.end()) {
+      // name was generated from base_name, has to succeed
+      size_t base_name_index = param.get_name().find(base_name);
+      size_t param_name_index = base_name_index + base_name.size();
+
+      // Check if scoped parameter name
+      if (param.get_name().substr(param_name_index + 1, getTransportName().size()) ==
+        getTransportName())
+      {
+        param_name_index += getTransportName().size() + 1;
+      }
+
+      std::string recommended_name = base_name + "." + getTransportName() + "." +
+        param.get_name().substr(param_name_index + 1);
+
+      rclcpp::Parameter recommended_value = node_->get_parameter(recommended_name);
+
+      // do not emit warnings if deprecated value matches
+      if (param.get_value_message() == recommended_value.get_value_message()) {
+        continue;
+      }
+
+      RCLCPP_WARN_STREAM(logger_,
+          "parameter `" << param.get_name() << "` is deprecated; use canonical name: `" <<
+          recommended_name << "`");
+
+      parameters.push_back(rclcpp::Parameter(recommended_name, param.get_parameter_value()));
+    }
   }
 }
 

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -155,10 +155,12 @@ void TheoraPublisher::advertiseImpl(
   std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
-  // Add pre set parameter callback to handle deprecated parameters
-  pre_set_parameter_callback_handle_ =
-    node->add_pre_set_parameters_callback(std::bind(&TheoraPublisher::preSetParametersCallback,
+  if (ns_len > 1) {
+    // Add pre set parameter callback to handle deprecated parameters
+    pre_set_parameter_callback_handle_ =
+      node->add_pre_set_parameters_callback(std::bind(&TheoraPublisher::preSetParametersCallback,
       this, std::placeholders::_1, param_base_name));
+  }
 
   // Add post set parameter callback to handle configuration changes
   post_set_parameter_callback_handle_ =

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -159,7 +159,7 @@ void TheoraPublisher::advertiseImpl(
     // Add pre set parameter callback to handle deprecated parameters
     pre_set_parameter_callback_handle_ =
       node->add_pre_set_parameters_callback(std::bind(&TheoraPublisher::preSetParametersCallback,
-      this, std::placeholders::_1, param_base_name));
+        this, std::placeholders::_1));
   }
 
   // Add post set parameter callback to handle configuration changes
@@ -452,40 +452,31 @@ void TheoraPublisher::declareParameter(
   }
 }
 
-void TheoraPublisher::preSetParametersCallback(
-  std::vector<rclcpp::Parameter> & parameters, std::string base_name)
+void TheoraPublisher::preSetParametersCallback(std::vector<rclcpp::Parameter> & parameters)
 {
+  std::vector<rclcpp::Parameter> new_parameters;
+
   for (auto & param : parameters) {
-    // Check if parameter is deprecated
-    if (deprecated_parameters_.find(param.get_name()) != deprecated_parameters_.end()) {
-      // name was generated from base_name, has to succeed
-      size_t base_name_index = param.get_name().find(base_name);
-      size_t param_name_index = base_name_index + base_name.size();
+    const auto & param_name = param.get_name();
 
-      // Check if scoped parameter name
-      if (param.get_name().substr(param_name_index + 1, getTransportName().size()) ==
-        getTransportName())
-      {
-        param_name_index += getTransportName().size() + 1;
-      }
-
-      std::string recommended_name = base_name + "." + getTransportName() + "." +
-        param.get_name().substr(param_name_index + 1);
-
-      rclcpp::Parameter recommended_value = node_->get_parameter(recommended_name);
-
-      // do not emit warnings if deprecated value matches
-      if (param.get_value_message() == recommended_value.get_value_message()) {
-        continue;
-      }
-
+    // Check if this is a deprecated dot-prefixed parameter for our transport
+    if (deprecated_parameters_.find(param_name) != deprecated_parameters_.end()) {
+      auto non_dot_prefixed_name = param_name.substr(1);
       RCLCPP_WARN_STREAM(logger_,
-          "parameter `" << param.get_name() << "` is deprecated; use canonical name: `" <<
-          recommended_name << "`");
+            "parameter `" << param_name << "` with leading dot character is deprecated; use: `" <<
+            non_dot_prefixed_name << "` instead");
+      new_parameters.push_back(
+          rclcpp::Parameter(non_dot_prefixed_name, param.get_parameter_value()));
+    }
 
-      parameters.push_back(rclcpp::Parameter(recommended_name, param.get_parameter_value()));
+    // Check if this is a normal parameter for our transport
+    if (std::find(parameters_.begin(), parameters_.end(), param_name) != parameters_.end()) {
+      // Also update the dot-prefixed parameter
+      new_parameters.emplace_back("." + param_name, param.get_parameter_value());
     }
   }
+
+  parameters.insert(parameters.end(), new_parameters.begin(), new_parameters.end());
 }
 
 void TheoraPublisher::postSetParametersCallback(

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -154,7 +154,8 @@ void TheoraPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
+  uint ns_prefix_len = ns_len > 1 ? ns_len + 1 : ns_len;
+  std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -37,9 +37,6 @@
 #include <sensor_msgs/image_encodings.hpp>
 #include <std_msgs/msg/header.hpp>
 
-#include <rclcpp/parameter_client.hpp>
-#include <rclcpp/parameter_events_filter.hpp>
-
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include "theora_image_transport/compression_common.hpp"
@@ -163,12 +160,10 @@ void TheoraPublisher::advertiseImpl(
     node->add_pre_set_parameters_callback(std::bind(&TheoraPublisher::preSetParametersCallback,
       this, std::placeholders::_1, param_base_name));
 
-  using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;
-  auto callback = std::bind(&TheoraPublisher::onParameterEvent, this, std::placeholders::_1,
-                            node->get_fully_qualified_name(), param_base_name);
-
-  parameter_subscription_ = rclcpp::SyncParametersClient::on_parameter_event<callbackT>(node,
-      callback);
+  // Add post set parameter callback to handle configuration changes
+  post_set_parameter_callback_handle_ =
+    node->add_post_set_parameters_callback(
+      std::bind(&TheoraPublisher::postSetParametersCallback, this, std::placeholders::_1));
 
   for(const ParameterDefinition & pd : kParameters) {
     declareParameter(param_base_name, pd);
@@ -491,21 +486,16 @@ void TheoraPublisher::preSetParametersCallback(
   }
 }
 
-void TheoraPublisher::onParameterEvent(
-  ParameterEvent::SharedPtr event, std::string full_name,
-  std::string /*base_name*/)
+void TheoraPublisher::postSetParametersCallback(
+  const std::vector<rclcpp::Parameter> & parameters)
 {
-  // filter out events from other nodes
-  if (event->node != full_name) {
-    return;
+  for (auto & param : parameters) {
+    // Check if parameter is from this transport
+    if (std::find(parameters_.begin(), parameters_.end(), param.get_name()) != parameters_.end()) {
+      refreshConfigNeeded = true;
+      break;
+    }
   }
-
-  // filter out new/changed deprecated parameters
-  using EventType = rclcpp::ParameterEventsFilter::EventType;
-
-  // if any of the non-deprecated parameters changed mark to refresh config
-  rclcpp::ParameterEventsFilter filterChanged(event, parameters_, {EventType::CHANGED});
-  refreshConfigNeeded = filterChanged.get_events().size() > 0;
 }
 
 }  // namespace theora_image_transport

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -438,6 +438,7 @@ void TheoraPublisher::declareParameter(
     param_value = node_->get_parameter(param_name).get_parameter_value();
   }
 
+  // TODO(anyone): Remove deprecated parameters after Lyrical release
   if (node_->get_effective_namespace().length() > 1) {
     // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
     const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +

--- a/zstd_image_transport/include/zstd_image_transport/zstd_publisher.hpp
+++ b/zstd_image_transport/include/zstd_image_transport/zstd_publisher.hpp
@@ -86,8 +86,7 @@ private:
     const std::string & base_name,
     const ParameterDefinition & definition);
 
-  void preSetParametersCallback(
-    std::vector<rclcpp::Parameter> & parameters, std::string base_name);
+  void preSetParametersCallback(std::vector<rclcpp::Parameter> & parameters);
 };
 
 }  // namespace zstd_image_transport

--- a/zstd_image_transport/include/zstd_image_transport/zstd_publisher.hpp
+++ b/zstd_image_transport/include/zstd_image_transport/zstd_publisher.hpp
@@ -36,6 +36,7 @@
 
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/compressed_image.hpp>
@@ -76,10 +77,17 @@ protected:
 
 private:
   std::vector<std::string> parameters_;
+  std::unordered_set<std::string> deprecated_parameters_;
+
+  rclcpp::node_interfaces::PreSetParametersCallbackHandle::SharedPtr
+    pre_set_parameter_callback_handle_;
 
   void declareParameter(
     const std::string & base_name,
     const ParameterDefinition & definition);
+
+  void preSetParametersCallback(
+    std::vector<rclcpp::Parameter> & parameters, std::string base_name);
 };
 
 }  // namespace zstd_image_transport

--- a/zstd_image_transport/src/zstd_publisher.cpp
+++ b/zstd_image_transport/src/zstd_publisher.cpp
@@ -88,6 +88,11 @@ void ZstdPublisher::advertiseImpl(
   std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
+  // Add pre set parameter callback to handle deprecated parameters
+  pre_set_parameter_callback_handle_ =
+    node->add_pre_set_parameters_callback(std::bind(&ZstdPublisher::preSetParametersCallback,
+      this, std::placeholders::_1, param_base_name));
+
   for (const ParameterDefinition & pd : kParameters) {
     declareParameter(param_base_name, pd);
   }
@@ -170,6 +175,55 @@ void ZstdPublisher::declareParameter(
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
     param_value = node_->get_parameter(param_name).get_parameter_value();
+  }
+
+  if (node_->get_effective_namespace().length() > 1) {
+    // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
+    const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +
+      definition.descriptor.name;
+    deprecated_parameters_.insert(deprecated_dot_name);
+
+    try {
+      node_->declare_parameter(deprecated_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
+  }
+}
+
+void ZstdPublisher::preSetParametersCallback(
+  std::vector<rclcpp::Parameter> & parameters, std::string base_name)
+{
+  for (auto & param : parameters) {
+    // Check if parameter is deprecated
+    if (deprecated_parameters_.find(param.get_name()) != deprecated_parameters_.end()) {
+      // name was generated from base_name, has to succeed
+      size_t base_name_index = param.get_name().find(base_name);
+      size_t param_name_index = base_name_index + base_name.size();
+
+      // Check if scoped parameter name
+      if (param.get_name().substr(param_name_index + 1, getTransportName().size()) ==
+        getTransportName())
+      {
+        param_name_index += getTransportName().size() + 1;
+      }
+
+      std::string recommended_name = base_name + "." + getTransportName() + "." +
+        param.get_name().substr(param_name_index + 1);
+
+      rclcpp::Parameter recommended_value = node_->get_parameter(recommended_name);
+
+      // do not emit warnings if deprecated value matches
+      if (param.get_value_message() == recommended_value.get_value_message()) {
+        continue;
+      }
+
+      RCLCPP_WARN_STREAM(logger_,
+          "parameter `" << param.get_name() << "` is deprecated; use canonical name: `" <<
+          recommended_name << "`");
+
+      parameters.push_back(rclcpp::Parameter(recommended_name, param.get_parameter_value()));
+    }
   }
 }
 }  // namespace zstd_image_transport

--- a/zstd_image_transport/src/zstd_publisher.cpp
+++ b/zstd_image_transport/src/zstd_publisher.cpp
@@ -179,6 +179,7 @@ void ZstdPublisher::declareParameter(
     param_value = node_->get_parameter(param_name).get_parameter_value();
   }
 
+  // TODO(anyone): Remove deprecated parameters after Lyrical release
   if (node_->get_effective_namespace().length() > 1) {
     // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
     const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +

--- a/zstd_image_transport/src/zstd_publisher.cpp
+++ b/zstd_image_transport/src/zstd_publisher.cpp
@@ -84,7 +84,8 @@ void ZstdPublisher::advertiseImpl(
 
   // Declare Parameters
   unsigned int ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
+  uint ns_prefix_len = ns_len > 1 ? ns_len + 1 : ns_len;
+  std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   for (const ParameterDefinition & pd : kParameters) {

--- a/zstd_image_transport/src/zstd_publisher.cpp
+++ b/zstd_image_transport/src/zstd_publisher.cpp
@@ -88,10 +88,12 @@ void ZstdPublisher::advertiseImpl(
   std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
-  // Add pre set parameter callback to handle deprecated parameters
-  pre_set_parameter_callback_handle_ =
-    node->add_pre_set_parameters_callback(std::bind(&ZstdPublisher::preSetParametersCallback,
-      this, std::placeholders::_1, param_base_name));
+  if (ns_len > 1) {
+    // Add pre set parameter callback to handle deprecated parameters
+    pre_set_parameter_callback_handle_ =
+      node->add_pre_set_parameters_callback(std::bind(&ZstdPublisher::preSetParametersCallback,
+        this, std::placeholders::_1, param_base_name));
+  }
 
   for (const ParameterDefinition & pd : kParameters) {
     declareParameter(param_base_name, pd);

--- a/zstd_image_transport/src/zstd_publisher.cpp
+++ b/zstd_image_transport/src/zstd_publisher.cpp
@@ -92,7 +92,7 @@ void ZstdPublisher::advertiseImpl(
     // Add pre set parameter callback to handle deprecated parameters
     pre_set_parameter_callback_handle_ =
       node->add_pre_set_parameters_callback(std::bind(&ZstdPublisher::preSetParametersCallback,
-        this, std::placeholders::_1, param_base_name));
+        this, std::placeholders::_1));
   }
 
   for (const ParameterDefinition & pd : kParameters) {
@@ -193,39 +193,30 @@ void ZstdPublisher::declareParameter(
   }
 }
 
-void ZstdPublisher::preSetParametersCallback(
-  std::vector<rclcpp::Parameter> & parameters, std::string base_name)
+void ZstdPublisher::preSetParametersCallback(std::vector<rclcpp::Parameter> & parameters)
 {
+  std::vector<rclcpp::Parameter> new_parameters;
+
   for (auto & param : parameters) {
-    // Check if parameter is deprecated
-    if (deprecated_parameters_.find(param.get_name()) != deprecated_parameters_.end()) {
-      // name was generated from base_name, has to succeed
-      size_t base_name_index = param.get_name().find(base_name);
-      size_t param_name_index = base_name_index + base_name.size();
+    const auto & param_name = param.get_name();
 
-      // Check if scoped parameter name
-      if (param.get_name().substr(param_name_index + 1, getTransportName().size()) ==
-        getTransportName())
-      {
-        param_name_index += getTransportName().size() + 1;
-      }
-
-      std::string recommended_name = base_name + "." + getTransportName() + "." +
-        param.get_name().substr(param_name_index + 1);
-
-      rclcpp::Parameter recommended_value = node_->get_parameter(recommended_name);
-
-      // do not emit warnings if deprecated value matches
-      if (param.get_value_message() == recommended_value.get_value_message()) {
-        continue;
-      }
-
+    // Check if this is a deprecated dot-prefixed parameter for our transport
+    if (deprecated_parameters_.find(param_name) != deprecated_parameters_.end()) {
+      auto non_dot_prefixed_name = param_name.substr(1);
       RCLCPP_WARN_STREAM(logger_,
-          "parameter `" << param.get_name() << "` is deprecated; use canonical name: `" <<
-          recommended_name << "`");
+            "parameter `" << param_name << "` with leading dot character is deprecated; use: `" <<
+            non_dot_prefixed_name << "` instead");
+      new_parameters.push_back(
+          rclcpp::Parameter(non_dot_prefixed_name, param.get_parameter_value()));
+    }
 
-      parameters.push_back(rclcpp::Parameter(recommended_name, param.get_parameter_value()));
+    // Check if this is a normal parameter for our transport
+    if (std::find(parameters_.begin(), parameters_.end(), param_name) != parameters_.end()) {
+      // Also update the dot-prefixed parameter
+      new_parameters.emplace_back("." + param_name, param.get_parameter_value());
     }
   }
+
+  parameters.insert(parameters.end(), new_parameters.begin(), new_parameters.end());
 }
 }  // namespace zstd_image_transport


### PR DESCRIPTION
Fixes #109

I left the incorrect parameter names and mirror their changes to the correct ones. As #183 was just merged and the transports no longer subscribe to parameter events, I decided to implement mirroring using [pre set parameter callback](https://docs.ros.org/en/rolling/Concepts/Basic/About-Parameters.html#parameter-callbacks) which was designed specifically for this use case. 

The parameter event callback for theora transport, which checked if the configuration needs to be refreshed, was replaced by `post set parameter callback`.

This can be a bit problematic to backport to `jazzy` depending on whether we are allowed to break the ABI (I don't see any [REP 2004](https://ros.org/reps/rep-2004.html) Quality declaration).