### PR TITLE
Adding the include of cstdint

### DIFF
--- a/zstd_image_transport/src/zlib_cpp.hpp
+++ b/zstd_image_transport/src/zlib_cpp.hpp
@@ -35,6 +35,7 @@
 
 #include <zlib.h>
 
+#include <cstdint>
 #include <list>
 #include <memory>
 #include <tuple>


### PR DESCRIPTION
Issue fixed when compiling with GCC 15 (Yocto master)

.../src/zlib_cpp.hpp:47:3: error: 'uint8_t' does not name a type
|    47 |   uint8_t * ptr;
|       |   ^~~~~~~
| .../src/zlib_cpp.hpp:40:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
|    39 | #include <memory>
|   +++ |+#include <cstdint>
|    40 | #include <tuple>