### PR TITLE
[Jazzy] Fix inconsistent parameter names when running under a namespace

### DIFF
--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -115,7 +115,8 @@ void CompressedDepthPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
+  uint ns_prefix_len = ns_len > 1 ? ns_len + 1 : ns_len;
+  std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -164,8 +164,8 @@ void CompressedDepthPublisher::declareParameter(
   parameters_.push_back(param_name);
 
   // deprecated non-scoped parameter name (e.g. image_raw.png_level)
-  const std::string deprecated_name = base_name + "." + definition.descriptor.name;
-  deprecatedParameters_.push_back(deprecated_name);
+  const std::string deprecated_non_scoped_name = base_name + "." + definition.descriptor.name;
+  deprecatedParameters_.push_back(deprecated_non_scoped_name);
 
   rclcpp::ParameterValue param_value;
 
@@ -179,9 +179,33 @@ void CompressedDepthPublisher::declareParameter(
 
   // transport scoped parameter as default, otherwise we would overwrite
   try {
-    node_->declare_parameter(deprecated_name, param_value, definition.descriptor);
+    node_->declare_parameter(deprecated_non_scoped_name, param_value, definition.descriptor);
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+  }
+
+  if (node_->get_effective_namespace().length() > 1) {
+    // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
+    const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +
+      definition.descriptor.name;
+    deprecatedParameters_.push_back(deprecated_dot_name);
+
+    // deprecated non-scoped parameters starting with the dot character (e.g. .image_raw.format)
+    const std::string deprecated_non_scoped_dot_name = "." + base_name + "." +
+      definition.descriptor.name;
+    deprecatedParameters_.push_back(deprecated_non_scoped_dot_name);
+
+    try {
+      node_->declare_parameter(deprecated_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
+
+    try {
+      node_->declare_parameter(deprecated_non_scoped_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
   }
 }
 
@@ -209,9 +233,14 @@ void CompressedDepthPublisher::onParameterEvent(
     // name was generated from base_name, has to succeed
     size_t baseNameIndex = name.find(base_name);
     size_t paramNameIndex = baseNameIndex + base_name.size();
-    // e.g. `color.image_raw.` + `compressedDepth` + `png_level`
-    std::string recommendedName = name.substr(0,
-        paramNameIndex + 1) + transport + name.substr(paramNameIndex);
+
+    // Check if scoped parameter name
+    if (name.substr(paramNameIndex + 1, transport.size()) == transport) {
+      paramNameIndex += transport.size() + 1;
+    }
+
+    std::string recommendedName = base_name + "." + transport + "." +
+      name.substr(paramNameIndex + 1);
 
     rclcpp::Parameter recommendedValue = node_->get_parameter(recommendedName);
 
@@ -220,8 +249,9 @@ void CompressedDepthPublisher::onParameterEvent(
       continue;
     }
 
-    RCLCPP_WARN_STREAM(logger_, "parameter `" << name << "` is deprecated and ambiguous" <<
-                                "; use transport qualified name `" << recommendedName << "`");
+    RCLCPP_WARN_STREAM(logger_,
+        "parameter `" << name << "` is deprecated; use canonical transport qualified name `" <<
+        recommendedName << "`");
 
     node_->set_parameter(rclcpp::Parameter(recommendedName, it.second->value));
   }

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -376,8 +376,8 @@ void CompressedPublisher::declareParameter(
   parameters_.push_back(param_name);
 
   // deprecated non-scoped parameter name (e.g. image_raw.format)
-  const std::string deprecated_name = base_name + "." + definition.descriptor.name;
-  deprecatedParameters_.push_back(deprecated_name);
+  const std::string deprecated_non_scoped_name = base_name + "." + definition.descriptor.name;
+  deprecatedParameters_.push_back(deprecated_non_scoped_name);
 
   rclcpp::ParameterValue param_value;
 
@@ -391,9 +391,33 @@ void CompressedPublisher::declareParameter(
 
   // transport scoped parameter as default, otherwise we would overwrite
   try {
-    node_->declare_parameter(deprecated_name, param_value, definition.descriptor);
+    node_->declare_parameter(deprecated_non_scoped_name, param_value, definition.descriptor);
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+  }
+
+  if (node_->get_effective_namespace().length() > 1) {
+    // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
+    const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +
+      definition.descriptor.name;
+    deprecatedParameters_.push_back(deprecated_dot_name);
+
+    // deprecated non-scoped parameters starting with the dot character (e.g. .image_raw.format)
+    const std::string deprecated_non_scoped_dot_name = "." + base_name + "." +
+      definition.descriptor.name;
+    deprecatedParameters_.push_back(deprecated_non_scoped_dot_name);
+
+    try {
+      node_->declare_parameter(deprecated_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
+
+    try {
+      node_->declare_parameter(deprecated_non_scoped_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
   }
 }
 
@@ -420,9 +444,14 @@ void CompressedPublisher::onParameterEvent(
     // name was generated from base_name, has to succeed
     size_t baseNameIndex = name.find(base_name);
     size_t paramNameIndex = baseNameIndex + base_name.size();
-    // e.g. `color.image_raw.` + `compressed` + `format`
-    std::string recommendedName = name.substr(0,
-        paramNameIndex + 1) + transport + name.substr(paramNameIndex);
+
+    // Check if scoped parameter name
+    if (name.substr(paramNameIndex + 1, transport.size()) == transport) {
+      paramNameIndex += transport.size() + 1;
+    }
+
+    std::string recommendedName = base_name + "." + transport + "." +
+      name.substr(paramNameIndex + 1);
 
     rclcpp::Parameter recommendedValue = node_->get_parameter(recommendedName);
 
@@ -431,8 +460,9 @@ void CompressedPublisher::onParameterEvent(
       continue;
     }
 
-    RCLCPP_WARN_STREAM(logger_, "parameter `" << name << "` is deprecated and ambiguous" <<
-                                "; use transport qualified name `" << recommendedName << "`");
+    RCLCPP_WARN_STREAM(logger_,
+        "parameter `" << name << "` is deprecated; use canonical transport qualified name `" <<
+        recommendedName << "`");
 
     node_->set_parameter(rclcpp::Parameter(recommendedName, it.second->value));
   }

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -133,7 +133,8 @@ void CompressedPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
+  uint ns_prefix_len = ns_len > 1 ? ns_len + 1 : ns_len;
+  std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -427,8 +427,8 @@ void TheoraPublisher::declareParameter(
   parameters_.push_back(param_name);
 
   // deprecated non-scoped parameter name (e.g. image_raw.quality)
-  const std::string deprecated_name = base_name + "." + definition.descriptor.name;
-  deprecatedParameters_.push_back(deprecated_name);
+  const std::string deprecated_non_scoped_name = base_name + "." + definition.descriptor.name;
+  deprecatedParameters_.push_back(deprecated_non_scoped_name);
 
   rclcpp::ParameterValue param_value;
 
@@ -442,10 +442,33 @@ void TheoraPublisher::declareParameter(
 
   // transport scoped parameter as default, otherwise we would overwrite
   try {
-    node_->declare_parameter(deprecated_name, param_value, definition.descriptor);
+    node_->declare_parameter(deprecated_non_scoped_name, param_value, definition.descriptor);
   } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
     RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
-    node_->get_parameter(deprecated_name).get_parameter_value();
+  }
+
+  if (node_->get_effective_namespace().length() > 1) {
+    // deprecated parameters starting with the dot character (e.g. .image_raw.compressed.format)
+    const std::string deprecated_dot_name = "." + base_name + "." + transport_name + "." +
+      definition.descriptor.name;
+    deprecatedParameters_.push_back(deprecated_dot_name);
+
+    // deprecated non-scoped parameters starting with the dot character (e.g. .image_raw.format)
+    const std::string deprecated_non_scoped_dot_name = "." + base_name + "." +
+      definition.descriptor.name;
+    deprecatedParameters_.push_back(deprecated_non_scoped_dot_name);
+
+    try {
+      node_->declare_parameter(deprecated_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
+
+    try {
+      node_->declare_parameter(deprecated_non_scoped_dot_name, param_value, definition.descriptor);
+    } catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &) {
+      RCLCPP_DEBUG(logger_, "%s was previously declared", definition.descriptor.name.c_str());
+    }
   }
 }
 
@@ -473,9 +496,14 @@ void TheoraPublisher::onParameterEvent(
     // name was generated from base_name, has to succeed
     size_t baseNameIndex = name.find(base_name);
     size_t paramNameIndex = baseNameIndex + base_name.size();
-    // e.g. `color.image_raw.` + `theora` + `quality`
-    std::string recommendedName = name.substr(0,
-        paramNameIndex + 1) + transport + name.substr(paramNameIndex);
+
+    // Check if scoped parameter name
+    if (name.substr(paramNameIndex + 1, transport.size()) == transport) {
+      paramNameIndex += transport.size() + 1;
+    }
+
+    std::string recommendedName = base_name + "." + transport + "." +
+      name.substr(paramNameIndex + 1);
 
     rclcpp::Parameter recommendedValue = node_->get_parameter(recommendedName);
 
@@ -484,8 +512,9 @@ void TheoraPublisher::onParameterEvent(
       continue;
     }
 
-    RCLCPP_WARN_STREAM(logger_, "parameter `" << name << "` is deprecated" <<
-                                "; use transport qualified name `" << recommendedName << "`");
+    RCLCPP_WARN_STREAM(logger_,
+        "parameter `" << name << "` is deprecated; use canonical transport qualified name `" <<
+        recommendedName << "`");
 
     node_->set_parameter(rclcpp::Parameter(recommendedName, it.second->value));
   }

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -154,7 +154,8 @@ void TheoraPublisher::advertiseImpl(
 
   // Declare Parameters
   uint ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
+  uint ns_prefix_len = ns_len > 1 ? ns_len + 1 : ns_len;
+  std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   using callbackT = std::function<void(ParameterEvent::SharedPtr event)>;

--- a/zstd_image_transport/src/zstd_publisher.cpp
+++ b/zstd_image_transport/src/zstd_publisher.cpp
@@ -84,7 +84,8 @@ void ZstdPublisher::advertiseImpl(
 
   // Declare Parameters
   unsigned int ns_len = node->get_effective_namespace().length();
-  std::string param_base_name = base_topic.substr(ns_len);
+  uint ns_prefix_len = ns_len > 1 ? ns_len + 1 : ns_len;
+  std::string param_base_name = base_topic.substr(ns_prefix_len);
   std::replace(param_base_name.begin(), param_base_name.end(), '/', '.');
 
   for (const ParameterDefinition & pd : kParameters) {


### PR DESCRIPTION
This is an attempt to fix #109 for Jazzy version without breaking current ABI.