### PR TITLE
Export target in the modern way

### DIFF
--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -13,25 +13,55 @@ find_package(ament_cmake REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(OpenCV REQUIRED)
-
-include_directories(include ${OpenCV_INCLUDE_DIRS})
+find_package(OpenCV REQUIRED COMPONENTS core imgcodecs)
 
 add_library(
-    ${PROJECT_NAME}
-    SHARED
-    src/compressed_depth_publisher.cpp
-    src/compressed_depth_subscriber.cpp
-    src/manifest.cpp src/codec.cpp src/rvl_codec.cpp
+  codecs
+  SHARED
+  src/codec.cpp
+  src/rvl_codec.cpp
+)
+
+target_include_directories(
+  codecs
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+
+target_link_libraries(codecs
+  cv_bridge::cv_bridge
+  opencv_core
+  opencv_imgcodecs
+  ${rcl_interfaces_TARGETS}
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+)
+
+add_library(
+  ${PROJECT_NAME}
+  SHARED
+  src/compressed_depth_publisher.cpp
+  src/compressed_depth_subscriber.cpp
+)
+
+target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 target_link_libraries(${PROJECT_NAME}
-  ${OpenCV_LIBRARIES}
+  codecs
   image_transport::image_transport
   cv_bridge::cv_bridge
   rclcpp::rclcpp
+  opencv_core
+  opencv_imgcodecs
   pluginlib::pluginlib
   ${sensor_msgs_TARGETS}
 )
@@ -42,10 +72,27 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin
 )
 
+install(TARGETS codecs
+  EXPORT export_codecs
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  INCLUDES DESTINATION include
+)
+
 install(
   DIRECTORY "include/"
   DESTINATION include
 )
+
+ament_export_targets(export_codecs HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  cv_bridge
+  rcl_interfaces
+  rclcpp
+  OpenCV
+  sensor_msgs
+)
+
 pluginlib_export_plugin_description_file(image_transport
     compressed_depth_plugins.xml)
 
@@ -57,7 +104,7 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(rvl_codec_test test/rvl_codec_test.cpp)
-  target_link_libraries(rvl_codec_test ${PROJECT_NAME})
+  target_link_libraries(rvl_codec_test codecs ${PROJECT_NAME})
 endif()
 
 ament_package()

--- a/compressed_depth_image_transport/package.xml
+++ b/compressed_depth_image_transport/package.xml
@@ -17,6 +17,11 @@
 
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
+  <depend>libopencv-dev</depend>
+  <depend>pluginlib</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Note to maintainers: my take on this is that we should split in two libraries: one containing encoder/decoder(s) and the other the image_transport plugin. Then, only the first library should be exported.

Let me know if you want such development, I can push an updated patch. And then, I can do it for the other packages in this same repo.