### PR TITLE
Fix linter warning

### DIFF
--- a/zstd_image_transport/include/zstd_image_transport/zstd_publisher.hpp
+++ b/zstd_image_transport/include/zstd_image_transport/zstd_publisher.hpp
@@ -66,7 +66,7 @@ protected:
     rclcpp::Node * node,
     const std::string & base_topic,
     rclcpp::QoS custom_qos,
-    rclcpp::PublisherOptions options) override final;
+    rclcpp::PublisherOptions options) final;
 
   void publish(
     const sensor_msgs::msg::Image & message,


### PR DESCRIPTION
https://build.ros2.org/job/Rpr__image_transport_plugins__ubuntu_noble_amd64/46/testReport/zstd_image_transport/cpplint/readability_inheritance__4____tmp_ws_src_image_transport_plugins_zstd_image_transport_include_zstd_image_transport_zstd_publisher_hpp_69_/