### PR TITLE
[Jazzy]: Fix passing parameters to cv::imencode for OpenCV 4.7

### DIFF
--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -219,7 +219,6 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
 
   // Compression settings
   std::vector<int> params;
-  params.resize(3, 0);
 
   // Bit depth of image encoding
   int bitDepth = enc::bitDepth(message.encoding);
@@ -236,6 +235,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
   compressed->format += "; compressedDepth " + format;
 
   // Check input format
+  params.reserve(2);
   params[0] = cv::IMWRITE_PNG_COMPRESSION;
   params[1] = png_level;
 


### PR DESCRIPTION
This already got fixed in Noetic. See https://github.com/ros-perception/image_transport_plugins/pull/130