### PR TITLE
Fix issue when loading compressedDepth plugin

### DIFF
--- a/compressed_depth_image_transport/CMakeLists.txt
+++ b/compressed_depth_image_transport/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(
   SHARED
   src/compressed_depth_publisher.cpp
   src/compressed_depth_subscriber.cpp
+  src/manifest.cpp
 )
 
 target_include_directories(


### PR DESCRIPTION
Hi, when running list_transports I noticed that:
```
❯ ros2 run image_transport list_transports
Declared transports:
image_transport/compressed
image_transport/compressedDepth (*): Not available. Try 'catkin_make --pkg compressed_depth_image_transport'.
image_transport/foxglove
image_transport/raw
image_transport/theora
image_transport/zstd

Details:
----------
"image_transport/compressed"
 - Provided by package: compressed_image_transport
 - Publisher: 
      This plugin publishes a CompressedImage using either JPEG or PNG compression.
    
 - Subscriber: 
      This plugin decompresses a CompressedImage topic.
    
----------
"image_transport/compressedDepth"
*** Plugins are built, but could not be loaded. The package may need to be rebuilt or may not be compatible with this release of image_common. ***
 - Provided by package: compressed_depth_image_transport
 - Publisher: 
      This plugin publishes a compressed depth images using PNG compression.
    
 - Subscriber: 
      This plugin decodes a compressed depth images.
```

This is because the missing manifest.cpp in CMakeLists

After this pr:
```
❯ ros2 run image_transport list_transports
Declared transports:
image_transport/compressed
image_transport/compressedDepth
image_transport/foxglove
image_transport/raw
image_transport/theora
image_transport/zstd
```