### PR TITLE
Publish with uniqueptr for efficiency

### DIFF
--- a/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.hpp
+++ b/compressed_depth_image_transport/include/compressed_depth_image_transport/codec.hpp
@@ -48,7 +48,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
   const sensor_msgs::msg::CompressedImage & compressed_image);
 
 // Compress a depth image. Returns a null pointer on bad input.
-sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
+sensor_msgs::msg::CompressedImage::UniquePtr encodeCompressedDepthImage(
   const sensor_msgs::msg::Image & message,
   const std::string & format = "png",
   double depth_max = 10.0,

--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -203,7 +203,7 @@ sensor_msgs::msg::Image::SharedPtr decodeCompressedDepthImage(
   return sensor_msgs::msg::Image::SharedPtr();
 }
 
-sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
+sensor_msgs::msg::CompressedImage::UniquePtr encodeCompressedDepthImage(
   const sensor_msgs::msg::Image & message,
   const std::string & format,
   double depth_max,
@@ -211,7 +211,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
   int png_level)
 {
   // Compressed image message
-  sensor_msgs::msg::CompressedImage::SharedPtr compressed(new sensor_msgs::msg::CompressedImage());
+  auto compressed = std::make_unique<sensor_msgs::msg::CompressedImage>();
   compressed->header = message.header;
   compressed->format = message.encoding;
 
@@ -249,7 +249,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
       cv_ptr = cv_bridge::toCvCopy(message);
     } catch (cv_bridge::Exception & e) {
       RCLCPP_ERROR(logger, "%s", e.what());
-      return sensor_msgs::msg::CompressedImage::SharedPtr();
+      return sensor_msgs::msg::CompressedImage::UniquePtr();
     }
 
     const cv::Mat & depthImg = cv_ptr->image;
@@ -298,11 +298,11 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
                 cRatio, compressedImage.size());
           } else {
             RCLCPP_ERROR(logger, "cv::imencode (png) failed on input image");
-            return sensor_msgs::msg::CompressedImage::SharedPtr();
+            return sensor_msgs::msg::CompressedImage::UniquePtr();
           }
         } catch (cv::Exception & e) {
           RCLCPP_ERROR(logger, "%s", e.msg.c_str());
-          return sensor_msgs::msg::CompressedImage::SharedPtr();
+          return sensor_msgs::msg::CompressedImage::UniquePtr();
         }
       } else if (format == "rvl") {
         int numPixels = invDepthImg.rows * invDepthImg.cols;
@@ -325,7 +325,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
       cv_ptr = cv_bridge::toCvCopy(message);
     } catch (cv::Exception & e) {
       RCLCPP_ERROR(logger, "%s", e.msg.c_str());
-      return sensor_msgs::msg::CompressedImage::SharedPtr();
+      return sensor_msgs::msg::CompressedImage::UniquePtr();
     }
 
     const cv::Mat & depthImg = cv_ptr->image;
@@ -356,7 +356,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
               compressedImage.size());
         } else {
           RCLCPP_ERROR(logger, "cv::imencode (png) failed on input image");
-          return sensor_msgs::msg::CompressedImage::SharedPtr();
+          return sensor_msgs::msg::CompressedImage::UniquePtr();
         }
       } else if (format == "rvl") {
         int numPixels = cv_ptr->image.rows * cv_ptr->image.cols;
@@ -377,7 +377,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
       "Compressed Depth Image Transport - Compression requires single-channel 32bit-floating "
       " point or 16bit raw depth images (input format is: %s).",
         message.encoding.c_str());
-    return sensor_msgs::msg::CompressedImage::SharedPtr();
+    return sensor_msgs::msg::CompressedImage::UniquePtr();
   }
 
   if (compressedImage.size() > 0) {
@@ -391,7 +391,7 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
     return compressed;
   }
 
-  return sensor_msgs::msg::CompressedImage::SharedPtr();
+  return sensor_msgs::msg::CompressedImage::UniquePtr();
 }
 
 }  // namespace compressed_depth_image_transport

--- a/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
+++ b/compressed_depth_image_transport/src/compressed_depth_publisher.cpp
@@ -145,14 +145,14 @@ void CompressedDepthPublisher::publish(
   int cfg_png_level = node_param_interface_->get_parameter(
     parameters_[PNG_LEVEL]).get_value<int64_t>();
 
-  sensor_msgs::msg::CompressedImage::SharedPtr compressed_image =
+  auto compressed_image =
     encodeCompressedDepthImage(message,
                                cfg_format,
                                cfg_depth_max,
                                cfg_depth_quantization,
                                cfg_png_level);
   if (compressed_image) {
-    publisher->publish(*compressed_image);
+    publisher->publish(std::move(compressed_image));
   }
 }
 

--- a/compressed_image_transport/src/compressed_publisher.cpp
+++ b/compressed_image_transport/src/compressed_publisher.cpp
@@ -181,9 +181,9 @@ void CompressedPublisher::publish(
     parameters_[TIFF_YDPI]).get_value<int64_t>();
 
   // Compressed image message
-  sensor_msgs::msg::CompressedImage compressed;
-  compressed.header = message.header;
-  compressed.format = message.encoding;
+  auto compressed = std::make_unique<sensor_msgs::msg::CompressedImage>();
+  compressed->header = message.header;
+  compressed->format = message.encoding;
 
   // Compression settings
   std::vector<int> params;
@@ -210,7 +210,7 @@ void CompressedPublisher::publish(
         params.emplace_back(cfg_jpeg_quality);
 
         // Update ros message format header
-        compressed.format += "; jpeg compressed ";
+        compressed->format += "; jpeg compressed ";
 
         // Check input format
         if ((bitDepth == 8) || (bitDepth == 16)) {
@@ -219,15 +219,15 @@ void CompressedPublisher::publish(
           if (enc::isColor(message.encoding)) {
             // convert color images to BGR8 format
             targetFormat = "bgr8";
-            compressed.format += targetFormat;
+            compressed->format += targetFormat;
           } else if (enc::isBayer(message.encoding) && cfg_jpeg_compress_bayer) {
             // do not convert bayer format to mono
             targetFormat = message.encoding;
-            compressed.format += targetFormat;
+            compressed->format += targetFormat;
           } else {
             // convert gray images to mono8 format
             targetFormat = "mono8";
-            compressed.format += targetFormat;
+            compressed->format += targetFormat;
           }
 
           // OpenCV-ros bridge
@@ -237,12 +237,12 @@ void CompressedPublisher::publish(
               targetFormat);
 
             // Compress image
-            if (cv::imencode(".jpg", cv_ptr->image, compressed.data, params)) {
+            if (cv::imencode(".jpg", cv_ptr->image, compressed->data, params)) {
               float cRatio = static_cast<float>(cv_ptr->image.rows * cv_ptr->image.cols *
-                cv_ptr->image.elemSize() / compressed.data.size());
+                cv_ptr->image.elemSize() / compressed->data.size());
               RCLCPP_DEBUG(logger_,
                 "Compressed Image Transport - Codec: jpg, Compression Ratio: 1:%.2f (%lu bytes)",
-                cRatio, compressed.data.size());
+                cRatio, compressed->data.size());
             } else {
               RCLCPP_ERROR(logger_, "cv::imencode (jpeg) failed on input image");
             }
@@ -253,7 +253,7 @@ void CompressedPublisher::publish(
           }
 
           // Publish message
-          publisher->publish(compressed);
+          publisher->publish(std::move(compressed));
         } else {
           RCLCPP_ERROR(logger_,
             "Compressed Image Transport - JPEG compression requires 8/16-bit color format "
@@ -269,7 +269,7 @@ void CompressedPublisher::publish(
         params.emplace_back(cfg_png_level);
 
         // Update ros message format header
-        compressed.format += "; png compressed ";
+        compressed->format += "; png compressed ";
 
         // Check input format
         if ((bitDepth == 8) || (bitDepth == 16)) {
@@ -282,7 +282,7 @@ void CompressedPublisher::publish(
               targetFormat << "a";
             }
             targetFormat << bitDepth;
-            compressed.format += targetFormat.str();
+            compressed->format += targetFormat.str();
           }
 
           // OpenCV-ros bridge
@@ -292,12 +292,12 @@ void CompressedPublisher::publish(
               targetFormat.str());
 
             // Compress image
-            if (cv::imencode(".png", cv_ptr->image, compressed.data, params)) {
+            if (cv::imencode(".png", cv_ptr->image, compressed->data, params)) {
               float cRatio = static_cast<float>(cv_ptr->image.rows * cv_ptr->image.cols *
-                cv_ptr->image.elemSize() / compressed.data.size());
+                cv_ptr->image.elemSize() / compressed->data.size());
               RCUTILS_LOG_DEBUG(
                 "Compressed Image Transport - Codec: png, Compression Ratio: 1:%.2f (%lu bytes)",
-                cRatio, compressed.data.size());
+                cRatio, compressed->data.size());
             } else {
               RCUTILS_LOG_ERROR("cv::imencode (png) failed on input image");
             }
@@ -310,7 +310,7 @@ void CompressedPublisher::publish(
           }
 
           // Publish message
-          publisher->publish(compressed);
+          publisher->publish(std::move(compressed));
         } else {
           RCUTILS_LOG_ERROR(
           "Compressed Image Transport - PNG compression requires 8/16-bit "
@@ -323,7 +323,7 @@ void CompressedPublisher::publish(
     case TIFF:
       {
         // Update ros message format header
-        compressed.format += "; tiff compressed ";
+        compressed->format += "; tiff compressed ";
         int res_unit = -1;
         // See https://gitlab.com/libtiff/libtiff/-/blob/v4.3.0/libtiff/tiff.h#L282-284
         if (cfg_tiff_res_unit == "inch") {
@@ -353,12 +353,12 @@ void CompressedPublisher::publish(
             cv_bridge::CvImageConstPtr cv_ptr = cv_bridge::toCvShare(message, nullptr, "");
 
             // Compress image
-            if (cv::imencode(".tiff", cv_ptr->image, compressed.data, params)) {
+            if (cv::imencode(".tiff", cv_ptr->image, compressed->data, params)) {
               float cRatio = static_cast<float>(cv_ptr->image.rows * cv_ptr->image.cols *
-                cv_ptr->image.elemSize() / compressed.data.size());
+                cv_ptr->image.elemSize() / compressed->data.size());
               RCUTILS_LOG_DEBUG(
                 "Compressed Image Transport - Codec: tiff, Compression Ratio: 1:%.2f (%lu bytes)",
-                cRatio, compressed.data.size());
+                cRatio, compressed->data.size());
             } else {
               RCUTILS_LOG_ERROR("cv::imencode (tiff) failed on input image");
             }
@@ -371,7 +371,7 @@ void CompressedPublisher::publish(
           }
 
           // Publish message
-          publisher->publish(compressed);
+          publisher->publish(std::move(compressed));
         } else {
           RCUTILS_LOG_ERROR(
           "Compressed Image Transport - TIFF compression requires 8/16/32-bit encoded color format "

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -394,7 +394,6 @@ bool TheoraPublisher::ensureEncodingContext(
     stream_header_.push_back(theora_image_transport::msg::Packet());
     oggPacketToMsg(image.header, oggpacket, stream_header_.back());
     auto msg = std::make_unique<theora_image_transport::msg::Packet>(stream_header_.back());
-    RCLCPP_INFO(logger_, "[THEORA] Image compressed at address: %p", msg.get());
     publisher->publish(std::move(msg));
   }
   return true;

--- a/theora_image_transport/src/theora_publisher.cpp
+++ b/theora_image_transport/src/theora_publisher.cpp
@@ -264,7 +264,8 @@ void TheoraPublisher::publish(
   theora_image_transport::msg::Packet output;
   while ((rval = th_encode_packetout(encoding_context_.get(), 0, &oggpacket)) > 0) {
     oggPacketToMsg(message.header, oggpacket, output);
-    publisher->publish(output);
+    auto msg = std::make_unique<theora_image_transport::msg::Packet>(output);
+    publisher->publish(std::move(msg));
   }
   if (rval == TH_EFAULT) {
     RCLCPP_ERROR(logger_, "[theora] EFAULT in retrieving encoded video data packets");
@@ -392,7 +393,9 @@ bool TheoraPublisher::ensureEncodingContext(
   while (th_encode_flushheader(encoding_context_.get(), &comment, &oggpacket) > 0) {
     stream_header_.push_back(theora_image_transport::msg::Packet());
     oggPacketToMsg(image.header, oggpacket, stream_header_.back());
-    publisher->publish(stream_header_.back());
+    auto msg = std::make_unique<theora_image_transport::msg::Packet>(stream_header_.back());
+    RCLCPP_INFO(logger_, "[THEORA] Image compressed at address: %p", msg.get());
+    publisher->publish(std::move(msg));
   }
   return true;
 }

--- a/zstd_image_transport/src/zstd_publisher.cpp
+++ b/zstd_image_transport/src/zstd_publisher.cpp
@@ -116,46 +116,46 @@ void ZstdPublisher::publish(
     total_size += data->size;
   }
 
-  sensor_msgs::msg::CompressedImage compressed;
+  auto compressed = std::make_unique<sensor_msgs::msg::CompressedImage>();
 
   int metadata = 4 + 4 + 1 + 4 + 4 + message.encoding.size();
 
-  compressed.data.resize(total_size + metadata);
+  compressed->data.resize(total_size + metadata);
 
   size_t index = metadata;
   for (const auto & data : g_compressed_data) {
-    memcpy(&compressed.data[index], data->ptr, data->size);
+    memcpy(&compressed->data[index], data->ptr, data->size);
     index += data->size;
   }
 
-  compressed.data[0] = static_cast<uint8_t>(message.height & 0xFF);
-  compressed.data[1] = static_cast<uint8_t>(message.height >> 8) & 0xFF;
-  compressed.data[2] = static_cast<uint8_t>(message.height >> 16) & 0xFF;
-  compressed.data[3] = static_cast<uint8_t>(message.height >> 24) & 0xFF;
+  compressed->data[0] = static_cast<uint8_t>(message.height & 0xFF);
+  compressed->data[1] = static_cast<uint8_t>(message.height >> 8) & 0xFF;
+  compressed->data[2] = static_cast<uint8_t>(message.height >> 16) & 0xFF;
+  compressed->data[3] = static_cast<uint8_t>(message.height >> 24) & 0xFF;
 
-  compressed.data[4] = static_cast<uint8_t>(message.width & 0xFF);
-  compressed.data[5] = static_cast<uint8_t>(message.width >> 8) & 0xFF;
-  compressed.data[6] = static_cast<uint8_t>(message.width >> 16) & 0xFF;
-  compressed.data[7] = static_cast<uint8_t>(message.width >> 24) & 0xFF;
+  compressed->data[4] = static_cast<uint8_t>(message.width & 0xFF);
+  compressed->data[5] = static_cast<uint8_t>(message.width >> 8) & 0xFF;
+  compressed->data[6] = static_cast<uint8_t>(message.width >> 16) & 0xFF;
+  compressed->data[7] = static_cast<uint8_t>(message.width >> 24) & 0xFF;
 
-  compressed.data[8] = message.is_bigendian;
+  compressed->data[8] = message.is_bigendian;
 
-  compressed.data[9] = static_cast<uint8_t>(message.step & 0xFF);
-  compressed.data[10] = static_cast<uint8_t>(message.step >> 8) & 0xFF;
-  compressed.data[11] = static_cast<uint8_t>(message.step >> 16) & 0xFF;
-  compressed.data[12] = static_cast<uint8_t>(message.step >> 24) & 0xFF;
+  compressed->data[9] = static_cast<uint8_t>(message.step & 0xFF);
+  compressed->data[10] = static_cast<uint8_t>(message.step >> 8) & 0xFF;
+  compressed->data[11] = static_cast<uint8_t>(message.step >> 16) & 0xFF;
+  compressed->data[12] = static_cast<uint8_t>(message.step >> 24) & 0xFF;
 
-  compressed.data[13] = static_cast<uint8_t>(message.encoding.size() & 0xFF);
-  compressed.data[14] = static_cast<uint8_t>(message.encoding.size() >> 8) & 0xFF;
-  compressed.data[15] = static_cast<uint8_t>(message.encoding.size() >> 16) & 0xFF;
-  compressed.data[16] = static_cast<uint8_t>(message.encoding.size() >> 24) & 0xFF;
+  compressed->data[13] = static_cast<uint8_t>(message.encoding.size() & 0xFF);
+  compressed->data[14] = static_cast<uint8_t>(message.encoding.size() >> 8) & 0xFF;
+  compressed->data[15] = static_cast<uint8_t>(message.encoding.size() >> 16) & 0xFF;
+  compressed->data[16] = static_cast<uint8_t>(message.encoding.size() >> 24) & 0xFF;
 
-  memcpy(&compressed.data[17], &message.encoding[0], message.encoding.size());
+  memcpy(&compressed->data[17], &message.encoding[0], message.encoding.size());
 
   // Compressed image message
-  compressed.header = message.header;
-  compressed.format = "zstd";
-  publisher->publish(compressed);
+  compressed->header = message.header;
+  compressed->format = "zstd";
+  publisher->publish(std::move(compressed));
 }
 
 void ZstdPublisher::declareParameter(


### PR DESCRIPTION
This PR updates the image transport plugins to use std::unique_ptr and std::move when publishing messages. This is beneficial when using intra-process communication