### PR TITLE
feat: support rcl buffer type

### DIFF
--- a/compressed_image_transport/src/compressed_subscriber.cpp
+++ b/compressed_image_transport/src/compressed_subscriber.cpp
@@ -103,7 +103,8 @@ void CompressedSubscriber::internalCallback(
 
   // Decode color/mono image
   try {
-    cv_ptr->image = cv::imdecode(cv::Mat(message->data), cfg_imdecode_flag);
+    const auto & compressed_data = static_cast<const std::vector<unsigned char> &>(message->data);
+    cv_ptr->image = cv::imdecode(compressed_data, cfg_imdecode_flag);
 
     // Assign image encoding string
     const size_t split_pos = message->format.find(';');


### PR DESCRIPTION
- message->data is now a rosidl::Buffer<unsigned char>, so cv::Mat(message->data) no longer matches OpenCV’s std::vector constructor path.
- add an explicit conversion from rosidl::Buffer<uint8_t> to the std::vector<uint8_t>