### PR TITLE
fix(compressed_depth): use push_back instead of index assignment

### DIFF
--- a/compressed_depth_image_transport/src/codec.cpp
+++ b/compressed_depth_image_transport/src/codec.cpp
@@ -235,9 +235,8 @@ sensor_msgs::msg::CompressedImage::SharedPtr encodeCompressedDepthImage(
   compressed->format += "; compressedDepth " + format;
 
   // Check input format
-  params.reserve(2);
-  params[0] = cv::IMWRITE_PNG_COMPRESSION;
-  params[1] = png_level;
+  params.push_back(cv::IMWRITE_PNG_COMPRESSION);
+  params.push_back(png_level);
 
   if ((bitDepth == 32) && (numChannels == 1)) {
     float depthZ0 = depth_quantization;


### PR DESCRIPTION
params.reserve(2) does not resize the vector, so params[0] and params[1] were out-of-bounds accesses causing an abort. Replace with push_back.

The prior fix in 1d964fb removed params.resize(3,0) which fixed the odd-length OpenCV params bug but introduced this crash.